### PR TITLE
Silly useQuery/useMutation implementation

### DIFF
--- a/examples/posts-and-counter/src/features/counter/Counter.tsx
+++ b/examples/posts-and-counter/src/features/counter/Counter.tsx
@@ -5,10 +5,9 @@ import { useQuery, useMutation } from '@rtk-incubator/simple-query/dist';
 
 export function Counter() {
   // const { data } = counterApi.hooks.getCount.useQuery();
-  const { data } = useQuery(counterApi, 'getCount') as any;
+  const { data } = useQuery(counterApi, 'getCount');
   const [increment, incrementResult] = useMutation(counterApi, 'incrementCount');
   // const [increment, incrementResult] = counterApi.hooks.incrementCount.useMutation();
-
   const [decrement, decrementResult] = counterApi.hooks.decrementCount.useMutation();
 
   return (

--- a/examples/posts-and-counter/src/features/counter/Counter.tsx
+++ b/examples/posts-and-counter/src/features/counter/Counter.tsx
@@ -6,8 +6,9 @@ import { useQuery, useMutation } from '@rtk-incubator/simple-query/dist';
 export function Counter() {
   // const { data } = counterApi.hooks.getCount.useQuery();
   const { data } = useQuery(counterApi, 'getCount');
+
   const [increment, incrementResult] = useMutation(counterApi, 'incrementCount');
-  // const [increment, incrementResult] = counterApi.hooks.incrementCount.useMutation();
+  const { data: banana } = counterApi.hooks.getCount.useQuery();
   const [decrement, decrementResult] = counterApi.hooks.decrementCount.useMutation();
 
   return (

--- a/examples/posts-and-counter/src/features/counter/Counter.tsx
+++ b/examples/posts-and-counter/src/features/counter/Counter.tsx
@@ -1,35 +1,24 @@
-import React from "react";
-import styles from "./Counter.module.css";
-import { counterApi } from "../../app/services/counter";
+import React from 'react';
+import styles from './Counter.module.css';
+import { counterApi } from '../../app/services/counter';
+import { useQuery, useMutation } from '@rtk-incubator/simple-query/dist';
 
 export function Counter() {
-  const { data } = counterApi.hooks.getCount.useQuery();
-  const [
-    increment,
-    incrementResult
-  ] = counterApi.hooks.incrementCount.useMutation();
+  // const { data } = counterApi.hooks.getCount.useQuery();
+  const { data } = useQuery(counterApi, 'getCount') as any;
+  const [increment, incrementResult] = useMutation(counterApi, 'incrementCount');
+  // const [increment, incrementResult] = counterApi.hooks.incrementCount.useMutation();
 
-  const [
-    decrement,
-    decrementResult
-  ] = counterApi.hooks.decrementCount.useMutation();
+  const [decrement, decrementResult] = counterApi.hooks.decrementCount.useMutation();
 
   return (
     <div>
       <div className={styles.row}>
-        <button
-          className={styles.button}
-          aria-label="Increment value"
-          onClick={() => increment(1)}
-        >
+        <button className={styles.button} aria-label="Increment value" onClick={() => increment(1)}>
           +
         </button>
         <span className={styles.value}>{data?.count || 0}</span>
-        <button
-          className={styles.button}
-          aria-label="Decrement value"
-          onClick={() => decrement(1)}
-        >
+        <button className={styles.button} aria-label="Decrement value" onClick={() => decrement(1)}>
           -
         </button>
       </div>

--- a/src/apiState.ts
+++ b/src/apiState.ts
@@ -15,10 +15,10 @@ export enum QueryStatus {
   rejected = 'rejected',
 }
 type Subscribers = string[];
-type QueryKeys<Definitions extends EndpointDefinitions> = {
+export type QueryKeys<Definitions extends EndpointDefinitions> = {
   [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any> ? K : never;
 }[keyof Definitions];
-type MutationKeys<Definitions extends EndpointDefinitions> = {
+export type MutationKeys<Definitions extends EndpointDefinitions> = {
   [K in keyof Definitions]: Definitions[K] extends MutationDefinition<any, any, any, any> ? K : never;
 }[keyof Definitions];
 type QueryArgs<D extends BaseEndpointDefinition<any, any, any>> = D extends BaseEndpointDefinition<infer QA, any, any>

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -59,6 +59,68 @@ export type Hooks<Definitions extends EndpointDefinitions> = {
     : never;
 };
 
+export function buildQueryHook(
+  name: string,
+  queryActions: QueryActions<any>,
+  querySelectors: QueryResultSelectors<any, any>
+): QueryHook<any> {
+  const startQuery = queryActions[name];
+  const querySelector = querySelectors[name];
+  return (arg, options) => {
+    const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
+    const skip = options?.skip === true;
+
+    const currentPromiseRef = useRef<QueryActionCreatorResult<any>>();
+
+    useEffect(() => {
+      if (skip) {
+        return;
+      }
+      const promise = dispatch(startQuery(arg));
+      currentPromiseRef.current = promise;
+      return () => void promise.unsubscribe();
+    }, [arg, dispatch, skip]);
+
+    const currentState = useSelector(querySelector(skip ? skipSelector : arg));
+    const refetch = useCallback(() => void currentPromiseRef.current?.refetch(), []);
+
+    return useMemo(() => ({ ...currentState, refetch }), [currentState, refetch]);
+  };
+}
+
+export function buildMutationHook(
+  name: string,
+  mutationActions: MutationActions<any>,
+  mutationSelectors: MutationResultSelectors<any, any>
+): MutationHook<any> {
+  return () => {
+    const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
+    const [requestId, setRequestId] = useState<string>();
+
+    const promiseRef = useRef<MutationActionCreatorResult<any>>();
+
+    useEffect(() => () => void promiseRef.current?.unsubscribe(), []);
+
+    const triggerMutation = useCallback(
+      function (args) {
+        let promise: MutationActionCreatorResult<any>;
+        batch(() => {
+          // false positive:
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          promiseRef.current?.unsubscribe();
+          promise = dispatch(mutationActions[name](args));
+          promiseRef.current = promise;
+          setRequestId(promise.requestId);
+        });
+        return promise!;
+      },
+      [dispatch]
+    );
+
+    return [triggerMutation, useSelector(mutationSelectors[name](requestId || skipSelector))];
+  };
+}
+
 export function buildHooks<Definitions extends EndpointDefinitions>({
   endpointDefinitions,
   querySelectors,
@@ -74,66 +136,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 }) {
   const hooks: Hooks<Definitions> = Object.entries(endpointDefinitions).reduce<Hooks<any>>((acc, [name, endpoint]) => {
     if (isQueryDefinition(endpoint)) {
-      acc[name] = { useQuery: buildQueryHook(name) };
+      acc[name] = { useQuery: buildQueryHook(name, queryActions, querySelectors) };
     } else if (isMutationDefinition(endpoint)) {
-      acc[name] = { useMutation: buildMutationHook(name) };
+      acc[name] = { useMutation: buildMutationHook(name, mutationActions, mutationSelectors) };
     }
     return acc;
   }, {});
 
   return { hooks };
-
-  function buildQueryHook(name: string): QueryHook<any> {
-    const startQuery = queryActions[name];
-    const querySelector = querySelectors[name];
-    return (arg, options) => {
-      const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
-      const skip = options?.skip === true;
-
-      const currentPromiseRef = useRef<QueryActionCreatorResult<any>>();
-
-      useEffect(() => {
-        if (skip) {
-          return;
-        }
-        const promise = dispatch(startQuery(arg));
-        currentPromiseRef.current = promise;
-        return () => void promise.unsubscribe();
-      }, [arg, dispatch, skip]);
-
-      const currentState = useSelector(querySelector(skip ? skipSelector : arg));
-      const refetch = useCallback(() => void currentPromiseRef.current?.refetch(), []);
-
-      return useMemo(() => ({ ...currentState, refetch }), [currentState, refetch]);
-    };
-  }
-
-  function buildMutationHook(name: string): MutationHook<any> {
-    return () => {
-      const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
-      const [requestId, setRequestId] = useState<string>();
-
-      const promiseRef = useRef<MutationActionCreatorResult<any>>();
-
-      useEffect(() => () => void promiseRef.current?.unsubscribe(), []);
-
-      const triggerMutation = useCallback(
-        function (args) {
-          let promise: MutationActionCreatorResult<any>;
-          batch(() => {
-            // false positive:
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            promiseRef.current?.unsubscribe();
-            promise = dispatch(mutationActions[name](args));
-            promiseRef.current = promise;
-            setRequestId(promise.requestId);
-          });
-          return promise!;
-        },
-        [dispatch]
-      );
-
-      return [triggerMutation, useSelector(mutationSelectors[name](requestId || skipSelector))];
-    };
-  }
 }

--- a/src/buildSelectors.ts
+++ b/src/buildSelectors.ts
@@ -1,5 +1,12 @@
 import { createNextState } from '@reduxjs/toolkit';
-import { MutationSubState, QueryStatus, QuerySubState, RootState as _RootState } from './apiState';
+import {
+  MutationSubState,
+  QueryStatus,
+  QueryKeys,
+  QuerySubState,
+  RootState as _RootState,
+  MutationKeys,
+} from './apiState';
 import {
   EndpointDefinitions,
   QueryDefinition,
@@ -12,13 +19,13 @@ import type { InternalState } from './buildSlice';
 export const skipSelector = Symbol('skip selector');
 
 export type QueryResultSelectors<Definitions extends EndpointDefinitions, RootState> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<infer QueryArg, any, any, infer ResultType>
+  [K in QueryKeys<Definitions>]: Definitions[K] extends QueryDefinition<infer QueryArg, any, any, infer ResultType>
     ? (queryArg: QueryArg | typeof skipSelector) => (state: RootState) => QuerySubState<Definitions[K]>
     : never;
 };
 
 export type MutationResultSelectors<Definitions extends EndpointDefinitions, RootState> = {
-  [K in keyof Definitions]: Definitions[K] extends MutationDefinition<any, any, any, infer ResultType>
+  [K in MutationKeys<Definitions>]: Definitions[K] extends MutationDefinition<any, any, any, infer ResultType>
     ? (requestId: string | typeof skipSelector) => (state: RootState) => MutationSubState<Definitions[K]>
     : never;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function defaultSerializeQueryArgs(args: any) {
   return JSON.stringify(args);
 }
 
-type CreateApiType = {
+interface CreateApiType {
   queryActions: QueryActions<any>;
   mutationActions: MutationActions<any>;
   selectors: {
@@ -23,10 +23,10 @@ type CreateApiType = {
     mutation: MutationResultSelectors<any, any>;
   };
   hooks: Hooks<any>;
-};
+}
 
 // Maybe this type of concept should be moved into a react specific package like `@rtk-incubator/simple-query/react`
-export const useQuery = <Service extends CreateApiType, Method extends keyof Service['hooks']>(
+export const useQuery = <Service extends CreateApiType, Method extends keyof Service['queryActions']>(
   service: Service,
   method: Method,
   opts?: QueryHookOptions
@@ -34,7 +34,7 @@ export const useQuery = <Service extends CreateApiType, Method extends keyof Ser
   return buildQueryHook(method as string, service.queryActions, service.selectors.query)(opts);
 };
 
-export const useMutation = <Service extends CreateApiType, Method extends keyof Service['hooks']>(
+export const useMutation = <Service extends CreateApiType, Method extends keyof Service['mutationActions']>(
   service: Service,
   method: Method
 ) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { buildThunks, QueryApi } from './buildThunks';
 import { buildSlice } from './buildSlice';
 import { buildActionMaps } from './buildActionMaps';
 import { buildSelectors } from './buildSelectors';
-import { buildHooks } from './buildHooks';
+import { buildHooks, buildQueryHook, buildMutationHook } from './buildHooks';
 import { buildMiddleware } from './buildMiddleware';
 import { EndpointDefinitions, EndpointBuilder, DefinitionType } from './endpointDefinitions';
 import type { CombinedState, QueryStatePhantomType } from './apiState';
@@ -14,6 +14,15 @@ export { QueryStatus } from './apiState';
 function defaultSerializeQueryArgs(args: any) {
   return JSON.stringify(args);
 }
+
+// Maybe this type of concept should be moved into a react specific package like `@rtk-incubator/simple-query/react`
+export const useQuery = (service: any, method: any, opts?: any) => {
+  return buildQueryHook(method, service.queryActions, service.selectors.query)(opts);
+};
+
+export const useMutation = (service: any, method: any) => {
+  return buildMutationHook(method, service.mutationActions, service.selectors.mutation)();
+};
 
 export function createApi<
   InternalQueryArgs,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "noErrorTruncation": true
   }
 }


### PR DESCRIPTION
This is just a test to 'see how it feels'. I don't know if I'd like this approach... but i think it could be TS-friendly? I think the better thing would probably be something like `useQuery(api, queries => queries.method(opts))`