### PR TITLE
change api shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ const store = configureStore({
 
 // usage in a component
 function DisplayUser({ id }: { id: number }) {
-  const { status, data } = api.hooks.getUser.useQuery(id);
-  const [updateUser, updateResult] = api.hooks.updateUser.useMutation();
+  const { status, data } = api.endpoints.getUser.useQuery(id);
+  const [updateUser, updateResult] = api.endpoints.updateUser.useMutation();
 
   if (status === QueryStatus.pending) {
     return <p>loading...</p>;

--- a/README.md
+++ b/README.md
@@ -1,210 +1,29 @@
+# RTK Query
+
+<p>
+  <img src="https://img.shields.io/badge/ALPHA-pre%20release-orange">
+   <a href="https://discord.gg/reactiflux" target="_blank">
+    <img src="https://img.shields.io/badge/chat-online-green" alt="Discord server" />
+  </a>
+</p>
+
 ## What this is:
 
-This is an experiment to create a generic api client based on (and potentially to be shipped with) redux toolkit that allows for effective querying of non-normalized api endpoints with some global caching & cache invalidation mechanisms.
+This is an experiment to create a generic api client based on (and potentially to be shipped with) [Redux Toolkit](https://redux-toolkit.js.org/) that allows for effective querying of non-normalized api endpoints with some global caching & cache invalidation mechanisms.
 
 ## Getting it / trying it out
 
 For now, look at [The CodeSandbox CI](https://ci.codesandbox.io/status/rtk-incubator/rtk-query/pr/1) for the latest experimental package builds and up-to-date example sandboxes.
 
-# Basic usage:
+Then follow along with the [Quick Start](https://rtk-query-docs.netlify.app/introduction/quick-start) - make sure to use the latest CodeSandbox build when installing :)
 
-```tsx
-import { configureStore } from '@reduxjs/toolkit';
-import { createApi, fetchBaseQuery, QueryStatus } from '@rtk-incubator/rtk-query';
+```sh title="Example installation"
+yarn add https://pkg.csb.dev/rtk-incubator/rtk-query/commit/0271589e/@rtk-incubator/rtk-query
 
-interface User {
-  id: number;
-  email: string;
-  first_name: string;
-  last_name: string;
-  avatar: string;
-}
-
-interface SingleResponse<T> {
-  data: T;
-}
-
-interface ListResponse<T> {
-  page: number;
-  per_page: number;
-  total: number;
-  total_pages: number;
-  data: T[];
-}
-
-// api initialization
-const api = createApi({
-  reducerPath: 'testApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://reqres.in/api' }),
-  entityTypes: [],
-  endpoints: (builder) => ({
-    listUsers: builder.query<ListResponse<User>, number | void>({
-      query(page = 1) {
-        return {
-          url: `users?page=${page}`,
-        };
-      },
-    }),
-    getUser: builder.query<SingleResponse<User>, number>({
-      query(id) {
-        return {
-          url: `users/${id}`,
-        };
-      },
-    }),
-    createUser: builder.mutation<User, Partial<User>>({
-      query(data) {
-        return {
-          url: `users`,
-          method: 'POST',
-          body: data,
-        };
-      },
-    }),
-    updateUser: builder.mutation<User, { id: number; patch: Partial<User> }>({
-      query({ id, patch }) {
-        return {
-          url: `users/${id}`,
-          method: 'PATCH',
-          body: patch,
-        };
-      },
-    }),
-    deleteUser: builder.mutation<void, number>({
-      query(id) {
-        return {
-          url: `users/${id}`,
-          method: 'DELETE',
-        };
-      },
-    }),
-  }),
-});
-
-// store setup
-const store = configureStore({
-  reducer: {
-    testApi: api.reducer, // "testApi" here has to match the `reducerPath` option for `createApi`
-  },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
-});
-
-// usage in a component
-function DisplayUser({ id }: { id: number }) {
-  const { status, data } = api.endpoints.getUser.useQuery(id);
-  const [updateUser, updateResult] = api.endpoints.updateUser.useMutation();
-
-  if (status === QueryStatus.pending) {
-    return <p>loading...</p>;
-  }
-  return (
-    <div>
-      <p>
-        first name: {data.data.first_name} <br />
-        last name: {data.data.last_name} <br />
-      </p>
-      <button onClick={() => updateUser({ id, patch: { first_name: 'Alice' } })}>set first name to Alice</button>
-    </div>
-  );
-}
 ```
 
-This allows to easily query data from the server and send requests to the server using the hooks supplied by our `api`.
+## Documentation
 
-# basic invalidation
+**_Note: this is being updated frequently as we're in alpha_**
 
-```diff
-const api = createApi({
-  reducerPath: 'testApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://reqres.in/api' }),
--  entityTypes: [],
-+  entityTypes: ['User'],
-  endpoints: (builder) => ({
-    listUsers: builder.query<ListResponse<User>, number | void>({
-      query(page = 1) {
-        return {
-          url: `users?page=${page}`,
-        };
-      },
-+      provides: [{type: 'User'}]
-    }),
-    // ...
-    createUser: builder.mutation<User, Partial<User>>({
-      query(data) {
-        return {
-          url: `users`,
-          method: 'POST',
-          body: data,
-        };
-      },
-+      invalidates: [{type: 'User'}]
-    }),
-```
-
-Now, whenever the `createUser` mutation is triggered, all currently used queries that provide objects of type `User` will re-run.
-
-# granular invalidation
-
-```diff
-const api = createApi({
-  reducerPath: 'testApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://reqres.in/api' }),
-  endpoints: (builder) => ({
-    listUsers: builder.query<ListResponse<User>, number | void>({
-      query(page = 1) {
-        return {
-          url: `users?page=${page}`,
-        };
-      },
--      provides: [{type: 'User'}]
-+      provides: result => [...result.data.map(user => ({type: 'User', id: user.id} as const)), {type: 'User', id: 'LIST'}]
-    }),
-    getUser: builder.query<SingleResponse<User>, number>({
-      query(id) {
-        return {
-          url: `users/${id}`,
-        };
-      },
--      provides: [{type: 'User'}]
-+      provides: (_, arg) => [({type: 'User', id: arg})]
-    }),
-    createUser: builder.mutation<User, Partial<User>>({
-      query(data) {
-        return {
-          url: `users`,
-          method: 'POST',
-          body: data,
-        };
-      },
--      invalidates: [{type: 'User'}]
-+      invalidates: [{type: 'User', id: 'LIST'}]
-    }),
-    updateUser: builder.mutation<User, { id: number; patch: Partial<User> }>({
-      query({ id, patch }) {
-        return {
-          url: `users/${id}`,
-          method: 'PATCH',
-          body: patch,
-        };
-      },
--      invalidates: [{type: 'User'}]
-+      invalidates: result => [{type: 'User', id: result.id}]
-    }),
-    deleteUser: builder.mutation<void, number>({
-      query(id) {
-        return {
-          url: `users/${id}`,
-          method: 'DELETE',
-        };
-      },
--      invalidates: [{type: 'User'}]
-+      invalidates: (_, arg) => [({type: 'User', id: arg})]
-    }),
-```
-
-notable things:
-
-- `invalidates` and `provides` can both be an array of `{entity: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument and the argument originally passed into the `query` method as the second argument.
-- `updateUser` and `deleteUser` will now invalidate only queries that provided entities with these specific ids
-- likewise, `getUser` now provides an entity with a specific id
-- `listUsers` now provides all entities with id from the fetch result. Also, it provides a User with the id `"LIST"`. This id is chosen arbitrarily. It enables `createUser` to invalidate all list-type queries - after all, depending of the sort order, that newly created user could show up in any of those lists.
+The working documentation can be [viewed here](https://rtk-query-docs.netlify.app/). In addition, you can check out the generated deploy previews on any PR before things land in `main`.

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -27,9 +27,16 @@ The main point where you will define a service to use in your application.
 - [`reducerPath`](#reducerpath)
 - [`reducer`](#reducer)
 - [`middleware`](#middleware)
-- [`actions`](#actions)
-- [`selectors`](#selectors)
-- [`hooks`](#hooks)
+- [`endpoints`](#endpoints-returned-by-createapi)
+  - **[endpointName]**
+    - [`initiate`](#actions)
+    - [`select`](#select)
+    - [`useQuery or useMutation`](#hooks)
+- [`internalActions`](#internalactions)
+- [`util`](#util)
+- [`injectEndpoints`](#injectendpoints)
+- [`usePrefetch`](../concepts/prefetching#prefetching-with-react-hooks)
+- [`Auto-generated hooks`](#auto-generated-hooks)
 
 ```ts title="All returned properties"
 const api = createApi({
@@ -39,7 +46,17 @@ const api = createApi({
   }),
 });
 
-export const { reducerPath, reducer, middleware, hooks, actions, selectors } = api;
+export const {
+  reducerPath,
+  reducer,
+  middleware,
+  endpoints,
+  internalActions,
+  util,
+  injectEndpoints,
+  usePrefetch,
+  ...generatedHooks
+} = api;
 ```
 
 #### middleware
@@ -50,6 +67,8 @@ This is a standard redux middleware and is responsible for things like [polling]
 
 A standard redux reducer that enables core functionality. Make sure it's [included in your store](../introduction/quick-start#add-the-service-to-your-store).
 
+### `endpoints` returned by `createApi`
+
 #### actions
 
 React Hooks users will most likely never need to use these in most cases. These are redux action creators that you can `dispatch` with `useDispatch` or `store.dispatch()`.
@@ -58,28 +77,36 @@ React Hooks users will most likely never need to use these in most cases. These 
 When dispatching an action creator, you're responsible for storing a reference to the promise it returns in the event that you want to update that specific subscription. To get an idea of what that entails, see the [Svelte Example](../examples/svelte) or the [React Class Components Example](../examples/react-class-components)
 :::
 
-#### selectors
+#### select
 
-Selectors are how you access your `query` or `mutation` data from the cache. If you're using Hooks, you don't have to worry about these in most cases. There are several ways to use them:
+`select` is how you access your `query` or `mutation` data from the cache. If you're using Hooks, you don't have to worry about this in most cases. There are several ways to use them:
 
-```js title="React
-// hooks
-const { data, status } = useSelector(selectors.getPosts());
+```js title="React Hooks"
+const { data, status } = useSelector(api.getPosts.select());
+```
 
-// class component with connect
+```js title="Using connect from react-redux"
 const mapStateToProps = (state) => ({
-  data: selectors.getPosts(state),
+  data: api.getPosts.select()(state),
 });
 connect(null, mapStateToProps);
 ```
 
 ```js title="Svelte"
-$: ({ data, status } = selectors.getPosts()($store));
+$: ({ data, status } = api.getPosts.select()($store));
 ```
 
 #### hooks
 
-Hooks are specifically for React Hooks users. If you are not using React Hooks, you shouldn't `export` them – this way they don't pull in the React dependency.
+Hooks are specifically for React Hooks users. Under each `api.endpoint.[endpointName]`, you will have `useQuery` or `useMutation` depending on the type. For example, if you had `getPosts` and `updatePost`, these options would be available:
+
+```ts title="Hooks usage"
+const { data } = api.endpoints.getPosts.useQuery();
+const { data } = api.endpoints.updatePost.useMutation();
+
+const { data } = api.useGetPostsQuery();
+const [updatePost] = api.useUpdatePostMutation();
+```
 
 ### `baseQuery`
 
@@ -155,7 +182,7 @@ Endpoints are just a set of operations that you want to perform against your ser
 
 #### How endpoints get used
 
-When defining a key like `getPosts` as shown below, it's important to know that this name will become exportable from `api` and be able to referenced under `api.endpoints.getPosts`, `api.selectors.getPosts`, and `api.actions.getPosts`. The same thing applies to `mutation`s.
+When defining a key like `getPosts` as shown below, it's important to know that this name will become exportable from `api` and be able to referenced under `api.endpoints.getPosts.useQuery()`, `api.endpoints.getPosts.initiate()` and `api.endpoints.getPosts.select()`. The same thing applies to `mutation`s but they reference `useMutation` instead of `useQuery`.
 
 ```ts
 const api = createApi({
@@ -176,16 +203,16 @@ const api = createApi({
   }),
 });
 
-// React users that use hooks are able to take advantage of this special feature
-// The syntax is `use(MethodName)(Query|Mutation)`
-// TS 4.1+ users will get type safety doing this as well
-export { useGetPostsQuery, useAddPostMutation } = api.hooks;
+// Auto-generated hooks
+export { useGetPostsQuery, useAddPostMutation } = api;
 
 // Possible exports
-
-export const { selectors, actions, reducerPath, reducer, middleware } = api;
+export const { endpoints, reducerPath, reducer, middleware } = api;
 // reducerPath, reducer, middleware are only used in store configuration
-// selectors/actions will have: selectors.getPosts, selectors.addPost, actions.getPosts, actions.getPost
+// endpoints will have:
+// endpoints.getPosts.initiate(), endpoints.getPosts.select(), endpoints.getPosts.useQuery()
+// endpoints.addPost.initiate(), endpoints.addPost.select(), endpoints.addPost.useMutation()
+// see `createApi` overview for _all exports_
 ```
 
 #### Transforming the data returned by an endpoint before caching
@@ -230,6 +257,37 @@ export const api = createApi({
   }),
 });
 ```
+
+### Auto-generated Hooks
+
+React users are able to take advantage of auto-generated hooks. By default, `createApi` will automatically generate type-safe hooks (TS 4.1+ only) for you based on the name of your endpoints. The general format is `use(Endpointname)(Query|Mutation)` - `use` is prefixed, the first letter of your endpoint name is capitalized, then `Query` or `Mutation` is appended depending on the type.
+
+```js title="Auto-generated hooks example"
+const api = createApi({
+  baseQuery,
+  endpoints: (build) => ({
+    getPosts: build.query({
+      query: () => 'posts',
+    }),
+    addPost: build.mutation({
+      query: (body) => ({
+        url: `posts`,
+        method: 'POST',
+        body,
+      }),
+    }),
+  }),
+});
+
+// Automatically generated from the endpoint names
+export { useGetPostsQuery, useAddPostMutation } = api;
+```
+
+### `internalActions`
+
+### `util`
+
+### `injectEndpoints`
 
 ### `keepUnusedDataFor`
 

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -155,7 +155,7 @@ Endpoints are just a set of operations that you want to perform against your ser
 
 #### How endpoints get used
 
-When defining a key like `getPosts` as shown below, it's important to know that this name will become exportable from `api` and be able to referenced under `api.hooks.getPosts`, `api.selectors.getPosts`, and `api.actions.getPosts`. The same thing applies to `mutation`s.
+When defining a key like `getPosts` as shown below, it's important to know that this name will become exportable from `api` and be able to referenced under `api.endpoints.getPosts`, `api.selectors.getPosts`, and `api.actions.getPosts`. The same thing applies to `mutation`s.
 
 ```ts
 const api = createApi({

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -20,12 +20,12 @@ This is a modified version of the complete example you can see at the bottom of 
 export const PostDetail = () => {
   const { id } = useParams<{ id: any }>();
 
-  const { data: post, status } = postApi.hooks.getPost.useQuery(id);
+  const { data: post, status } = postApi.endpoints.getPost.useQuery(id);
 
   const [
     updatePost, // This is the mutation trigger
     { status: updateStatus }, // You can inspect the status of the mutation
-  ] = postApi.hooks.updatePost.useMutation();
+  ] = postApi.endpoints.updatePost.useMutation();
 
   return (
     <Box p={4}>

--- a/examples/react/src/app/services/counter.ts
+++ b/examples/react/src/app/services/counter.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query/dist';
+import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 
 interface CountResponse {
   count: number;

--- a/examples/react/src/app/services/posts.ts
+++ b/examples/react/src/app/services/posts.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query/dist';
+import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 
 export interface Post {
   id: number;

--- a/examples/react/src/app/services/split/index.ts
+++ b/examples/react/src/app/services/split/index.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery, ApiWithInjectedEndpoints } from '@rtk-incubator/rtk-query/dist';
+import { createApi, fetchBaseQuery, ApiWithInjectedEndpoints } from '@rtk-incubator/rtk-query';
 
 export interface Post {
   id: number;

--- a/examples/react/src/features/bundleSplitting/Post.tsx
+++ b/examples/react/src/features/bundleSplitting/Post.tsx
@@ -24,8 +24,8 @@ const Post = ({ id }: { id: number }) => {
    * This missing would be a programming error that you should
    * catch early anyways.
    */
-  assert(splitApi.hooks.getPost, 'Endpoint `getPost` not loaded!');
-  const { data, error } = splitApi.hooks.getPost.useQuery(id);
+  assert(splitApi.endpoints.getPost?.useQuery, 'Endpoint `getPost` not loaded!');
+  const { data, error } = splitApi.endpoints.getPost.useQuery(id);
   return error ? <>there was an error</> : !data ? <>loading</> : <h1>{data.name}</h1>;
 };
 export default Post;

--- a/examples/react/src/features/bundleSplitting/PostsList.tsx
+++ b/examples/react/src/features/bundleSplitting/PostsList.tsx
@@ -13,9 +13,11 @@ const PostsList = () => {
    * injected though.
    */
 
-  const { data, error } = apiWithPosts.hooks.getPosts.useQuery();
+  const { data, error } = apiWithPosts.endpoints.getPosts.useQuery();
   const [selected, select] = useState<number | undefined>();
-  return error ? <>there was an error</> : !data ? (
+  return error ? (
+    <>there was an error</>
+  ) : !data ? (
     <>loading</>
   ) : (
     <>

--- a/examples/react/src/features/counter/Counter.tsx
+++ b/examples/react/src/features/counter/Counter.tsx
@@ -4,10 +4,10 @@ import { counterApi } from '../../app/services/counter';
 
 export function Counter({ id, onRemove }: { id?: string; onRemove?: () => void }) {
   const [pollingInterval, setPollingInterval] = useState(10000);
-  const { data } = counterApi.hooks.getCount.useQuery(undefined, { pollingInterval });
-  const [increment, incrementResult] = counterApi.hooks.incrementCount.useMutation();
+  const { data } = counterApi.endpoints.getCount.useQuery(undefined, { pollingInterval });
+  const [increment, incrementResult] = counterApi.endpoints.incrementCount.useMutation();
 
-  const [decrement, decrementResult] = counterApi.hooks.decrementCount.useMutation();
+  const [decrement, decrementResult] = counterApi.endpoints.decrementCount.useMutation();
 
   return (
     <div>

--- a/examples/react/src/features/posts/PostDetail.tsx
+++ b/examples/react/src/features/posts/PostDetail.tsx
@@ -35,7 +35,7 @@ const EditablePostName = ({
 };
 
 const PostJsonDetail = ({ id }: { id: number }) => {
-  const { data: post } = postApi.hooks.getPost.useQuery(id);
+  const { data: post } = postApi.endpoints.getPost.useQuery(id);
 
   return (
     <div className="row" style={{ background: '#eee' }}>
@@ -50,10 +50,10 @@ export const PostDetail = () => {
 
   const [isEditing, setIsEditing] = useState(false);
 
-  const { data: post, isFetching, isLoading } = postApi.hooks.getPost.useQuery(id, { pollingInterval: 3000 });
+  const { data: post, isFetching, isLoading } = postApi.endpoints.getPost.useQuery(id, { pollingInterval: 3000 });
 
-  const [updatePost, { isLoading: isUpdating }] = postApi.hooks.updatePost.useMutation();
-  const [deletePost, { isLoading: isDeleting }] = postApi.hooks.deletePost.useMutation();
+  const [updatePost, { isLoading: isUpdating }] = postApi.endpoints.updatePost.useMutation();
+  const [deletePost, { isLoading: isDeleting }] = postApi.endpoints.deletePost.useMutation();
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/examples/react/src/features/posts/PostDetail.tsx
+++ b/examples/react/src/features/posts/PostDetail.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import { QueryStatus } from '@rtk-incubator/rtk-query/dist';
 import { postApi } from '../../app/services/posts';
 
 const EditablePostName = ({

--- a/examples/react/src/features/posts/PostsManager.tsx
+++ b/examples/react/src/features/posts/PostsManager.tsx
@@ -1,4 +1,4 @@
-import { QueryStatus } from '@rtk-incubator/rtk-query/dist';
+import { QueryStatus } from '@rtk-incubator/rtk-query';
 import React, { useState } from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import { Post, postApi } from '../../app/services/posts';
@@ -8,8 +8,7 @@ import './PostsManager.css';
 const AddPost = () => {
   const initialValue = { name: '' };
   const [post, setPost] = useState<Partial<Post>>(initialValue);
-  const [addPost, { status }] = postApi.endpoints.addPost.useMutation();
-  const loading = status === QueryStatus.pending;
+  const [addPost, { isLoading }] = postApi.endpoints.addPost.useMutation();
 
   const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setPost((prev) => ({
@@ -26,8 +25,8 @@ const AddPost = () => {
         <input name="name" placeholder="New post name" type="text" onChange={handleChange} value={post.name} />
       </div>
       <div className="column column-1">
-        <button onClick={handleAddPost} disabled={loading}>
-          {loading ? 'Adding...' : 'Add Post'}
+        <button onClick={handleAddPost} disabled={isLoading}>
+          {isLoading ? 'Adding...' : 'Add Post'}
         </button>
       </div>
     </div>
@@ -45,10 +44,10 @@ const PostListItem = ({ data: { name, id }, onSelect }: { data: Post; onSelect: 
 };
 
 const PostList = () => {
-  const { data: posts, status } = postApi.endpoints.getPosts.useQuery();
+  const { data: posts, isLoading } = postApi.endpoints.getPosts.useQuery();
   const { push } = useHistory();
 
-  if (status === QueryStatus.pending) {
+  if (isLoading) {
     return <div>Loading</div>;
   }
 

--- a/examples/react/src/features/posts/PostsManager.tsx
+++ b/examples/react/src/features/posts/PostsManager.tsx
@@ -8,7 +8,7 @@ import './PostsManager.css';
 const AddPost = () => {
   const initialValue = { name: '' };
   const [post, setPost] = useState<Partial<Post>>(initialValue);
-  const [addPost, { status }] = postApi.hooks.addPost.useMutation();
+  const [addPost, { status }] = postApi.endpoints.addPost.useMutation();
   const loading = status === QueryStatus.pending;
 
   const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +45,7 @@ const PostListItem = ({ data: { name, id }, onSelect }: { data: Post; onSelect: 
 };
 
 const PostList = () => {
-  const { data: posts, status } = postApi.hooks.getPosts.useQuery();
+  const { data: posts, status } = postApi.endpoints.getPosts.useQuery();
   const { push } = useHistory();
 
   if (status === QueryStatus.pending) {

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -78,11 +78,11 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const canPoll = globalPolling && timesPolling;
 
   const [pollingInterval, setPollingInterval] = useState(0);
-  const { data, refetch, isLoading } = timeApi.endpoints.getTime.useQuery(offset, {
+  const { data, refetch, isFetching } = timeApi.endpoints.getTime.useQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
   });
   return (
-    <div style={{ ...(isLoading ? { background: '#e6ffe8' } : {}) }}>
+    <div style={{ ...(isFetching ? { background: '#e6ffe8' } : {}) }}>
       <p>
         {data?.time && new Date(data.time).toLocaleTimeString()} - {label}
       </p>

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -1,7 +1,6 @@
 import { nanoid } from '@reduxjs/toolkit';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
-import { QueryStatus } from '@rtk-incubator/rtk-query/dist';
 import { timeApi, usePrefetchTime } from '../../app/services/times';
 import { Container } from '../common/Container';
 import { useTypedSelector } from '../../app/store';
@@ -79,11 +78,11 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const canPoll = globalPolling && timesPolling;
 
   const [pollingInterval, setPollingInterval] = useState(0);
-  const { data, status, refetch, isLoading } = timeApi.endpoints.getTime.useQuery(offset, {
+  const { data, refetch, isLoading } = timeApi.endpoints.getTime.useQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
   });
   return (
-    <div style={{ ...(QueryStatus.pending === status ? { background: '#e6ffe8' } : {}) }}>
+    <div style={{ ...(isLoading ? { background: '#e6ffe8' } : {}) }}>
       <p>
         {data?.time && new Date(data.time).toLocaleTimeString()} - {label}
       </p>

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -79,7 +79,7 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const canPoll = globalPolling && timesPolling;
 
   const [pollingInterval, setPollingInterval] = useState(0);
-  const { data, status, refetch, isLoading } = timeApi.hooks.getTime.useQuery(offset, {
+  const { data, status, refetch, isLoading } = timeApi.endpoints.getTime.useQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
   });
   return (

--- a/examples/svelte/src/App.svelte
+++ b/examples/svelte/src/App.svelte
@@ -5,7 +5,7 @@
     import Counter from './Counter.svelte';
     import { nanoid } from '@reduxjs/toolkit';
 
-    const { actions, selectors } = counterApi;
+    const { endpoints } = counterApi;
 
     let counters: string[] = [];
     let spookyMode = true;
@@ -14,10 +14,10 @@
     let queryRef;
 
     onMount(async () => {
-        queryRef = { refetch: getCount } = store.dispatch(actions.getCount());
+        queryRef = { refetch: getCount } = store.dispatch(endpoints.getCount.initiate());
     });
 
-    $: ({ data } = selectors.getCount()($store));
+    $: ({ data } = endpoints.getCount.select()($store));
 </script>
 
 <style>
@@ -57,8 +57,8 @@
 
 <main>
     <h1>{data?.count || 0}</h1>
-    <button on:click={() => store.dispatch(actions.incrementCount(1, { track: false }))}>Increase</button>
-    <button on:click={() => store.dispatch(actions.decrementCount(1, { track: false }))}>Decrease</button>
+    <button on:click={() => store.dispatch(endpoints.incrementCount.initiate(1, { track: false }))}>Increase</button>
+    <button on:click={() => store.dispatch(endpoints.decrementCount.initiate(1, { track: false }))}>Decrease</button>
 
     <hr />
     <h3>Haunted counters?</h3>
@@ -86,7 +86,7 @@
                     class="button-link"
                     on:click|once={() => {
                         spookyMode = false;
-                        store.dispatch(actions.stop()).then(() => {
+                        store.dispatch(endpoints.stop.initiate()).then(() => {
                             spookyMode = false;
                             globalPollingEnabled.set(false);
                         });

--- a/examples/svelte/src/Counter.svelte
+++ b/examples/svelte/src/Counter.svelte
@@ -1,27 +1,27 @@
 <script lang="ts">
     export let id: string = null;
     import { onMount } from 'svelte';
-    import { QueryStatus } from '@rtk-incubator/rtk-query/dist';
+    import { QueryStatus } from '@rtk-incubator/rtk-query';
     import { counterApi } from './services/counter';
     import { globalPollingEnabled, store } from './store';
     import { pollingOptions } from './utils/pollingOptions';
 
-    const { actions, selectors } = counterApi;
+    const { endpoints: { getCountById, decrementCountById, incrementCountById} } = counterApi;
 
     // Set the initial to random option
     let pollingInterval = pollingOptions[Math.floor(Math.random() * pollingOptions.length)].value;
     let queryRef, lastIncrementRequestId, lastDecrementRequestId, incrementStatus, decrementStatus;
 
-    $: ({ data, status: getStatus } = selectors.getCountById(id)($store));
-    $: ({ status: decrementStatus } = selectors.decrementCountById(lastDecrementRequestId)($store));
-    $: ({ status: incrementStatus } = selectors.incrementCountById(lastIncrementRequestId)($store));
+    $: ({ data, status: getStatus } = getCountById.select(id)($store));
+    $: ({ status: decrementStatus } = decrementCountById.select(lastDecrementRequestId)($store));
+    $: ({ status: incrementStatus } = incrementCountById.select(lastIncrementRequestId)($store));
 
     $: loading = [incrementStatus, decrementStatus, getStatus].some((status) => status === QueryStatus.pending);
 
     $: queryRef?.updateSubscriptionOptions({ pollingInterval: $globalPollingEnabled ? pollingInterval : 0 });
 
     onMount(() => {
-        queryRef = store.dispatch(actions.getCountById(id));
+        queryRef = store.dispatch(getCountById.initiate(id));
     });
 </script>
 
@@ -46,10 +46,10 @@
 <main class={loading ? 'highlight' : ''}>
     <span class="count">{data?.count || 0}</span>
     <button
-        on:click={() => ({ requestId: lastIncrementRequestId } = store.dispatch(actions.incrementCountById({ id, amount: 1 }, { track: true })))}
+        on:click={() => ({ requestId: lastIncrementRequestId } = store.dispatch(incrementCountById.initiate({ id, amount: 1 }, { track: true })))}
         disabled={loading}>+</button>
     <button
-        on:click={() => ({ requestId: lastDecrementRequestId } = store.dispatch(actions.decrementCountById({ id, amount: 1 }, { track: true })))}
+        on:click={() => ({ requestId: lastDecrementRequestId } = store.dispatch(decrementCountById.initiate({ id, amount: 1 }, { track: true })))}
         disabled={loading}>-</button>
     <select bind:value={pollingInterval}>
         {#each pollingOptions as { value, label }}

--- a/examples/svelte/src/services/counter.ts
+++ b/examples/svelte/src/services/counter.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query/dist';
+import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 
 interface CountResponse {
     count: number;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prepare": "yarn build; ./prepare-examples.sh",
     "size": "size-limit",
     "format": "prettier --write \"src/**/*.ts\" \"**/*.md\"",
-    "analyze": "size-limit --why"
+    "analyze": "size-limit --why",
+    "list-unused-exports": "ts-unused-exports tsconfig.json"
   },
   "husky": {
     "hooks": {
@@ -85,7 +86,6 @@
   },
   "devDependencies": {
     "@reduxjs/toolkit": "https://pkg.csb.dev/reduxjs/redux-toolkit/commit/2c869f4d/@reduxjs/toolkit",
-    "immer": "^8.0.0",
     "@size-limit/preset-small-lib": "^4.6.0",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^3.4.2",
@@ -93,6 +93,7 @@
     "@types/react-redux": "^7.1.9",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
+    "immer": "^8.0.0",
     "prettier": "^2.2.0",
     "react": "^16.14.0 || 17.0.0",
     "react-dom": "^16.14.0 || 17.0.0",
@@ -100,6 +101,7 @@
     "react-test-renderer": "^17.0.1",
     "size-limit": "^4.6.0",
     "ts-node": "^9.0.0",
+    "ts-unused-exports": "^7.0.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.3"
   },

--- a/prepare-examples.sh
+++ b/prepare-examples.sh
@@ -3,7 +3,7 @@
 for example in examples/*; do (
     cd "$example" && test -f package.json || exit 0
     yarn install
-    mkdir -p node_modules/@rtk-incubator/rtk-query/dist
+    mkdir -p node_modules/@rtk-incubator/rtk-query
     rm -r node_modules/@rtk-incubator/rtk-query/{dist,package.json}
     ln -sv ../../../../../{dist,package.json} node_modules/@rtk-incubator/rtk-query
     rm -r node_modules/react node_modules/react-redux

--- a/src/apiState.ts
+++ b/src/apiState.ts
@@ -19,7 +19,7 @@ export enum QueryStatus {
   rejected = 'rejected',
 }
 
-export const defaultBaseFlagsState = {
+const defaultBaseFlagsState = {
   isUninitialized: true,
   isLoading: false,
   isSuccess: false,

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -1,3 +1,6 @@
+/**
+ * Note: this file should import all other files for type discovery and declaration merging
+ */
 import { PatchQueryResultThunk, UpdateQueryResultThunk } from './buildThunks';
 import { AnyAction, Middleware, Reducer, ThunkDispatch } from '@reduxjs/toolkit';
 import { PrefetchOptions } from './buildHooks';
@@ -12,6 +15,7 @@ import { CombinedState, QueryKeys, QueryStatePhantomType, RootState } from './ap
 import { InternalActions } from './index';
 import { UnionToIntersection } from './tsHelpers';
 import { TS41Hooks } from './ts41Types';
+import './buildSelectors';
 
 export type Api<
   BaseQuery extends (arg: any, ...args: any[]) => any,

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -1,0 +1,71 @@
+import { PatchQueryResultThunk, UpdateQueryResultThunk } from './buildThunks';
+import { AnyAction, Middleware, Reducer, ThunkDispatch } from '@reduxjs/toolkit';
+import { PrefetchOptions } from './buildHooks';
+import {
+  EndpointDefinitions,
+  EndpointBuilder,
+  QueryArgFrom,
+  QueryDefinition,
+  MutationDefinition,
+} from './endpointDefinitions';
+import { CombinedState, QueryKeys, QueryStatePhantomType, RootState } from './apiState';
+import { InternalActions } from './index';
+import { UnionToIntersection } from './tsHelpers';
+import { TS41Hooks } from './ts41Types';
+
+export type Api<
+  BaseQuery extends (arg: any, ...args: any[]) => any,
+  Definitions extends EndpointDefinitions,
+  ReducerPath extends string,
+  EntityTypes extends string
+> = {
+  reducerPath: ReducerPath;
+  internalActions: InternalActions;
+  reducer: Reducer<CombinedState<Definitions, EntityTypes> & QueryStatePhantomType<ReducerPath>, AnyAction>;
+  middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>>;
+  util: {
+    updateQueryResult: UpdateQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+    patchQueryResult: PatchQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+  };
+  // If you actually care about the return value, use useQuery
+  usePrefetch<EndpointName extends QueryKeys<Definitions>>(
+    endpointName: EndpointName,
+    options?: PrefetchOptions
+  ): (arg: QueryArgFrom<Definitions[EndpointName]>, options?: PrefetchOptions) => void;
+  injectEndpoints<NewDefinitions extends EndpointDefinitions>(_: {
+    endpoints: (build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>) => NewDefinitions;
+    overrideExisting?: boolean;
+  }): Api<BaseQuery, Definitions & NewDefinitions, ReducerPath, EntityTypes>;
+  endpoints: {
+    [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any, any>
+      ? ApiEndpointQuery<Definitions[K], Definitions>
+      : Definitions[K] extends MutationDefinition<any, any, any, any, any>
+      ? ApiEndpointMutation<Definitions[K], Definitions>
+      : never;
+  };
+} & TS41Hooks<Definitions>;
+
+export interface ApiEndpointQuery<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Definition extends QueryDefinition<any, any, any, any, any>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Definitions extends EndpointDefinitions
+> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface ApiEndpointMutation<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Definition extends MutationDefinition<any, any, any, any, any>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Definitions extends EndpointDefinitions
+> {}
+
+export type ApiWithInjectedEndpoints<
+  ApiDefinition extends Api<any, any, any, any>,
+  Injections extends ApiDefinition extends Api<infer B, any, infer R, infer E>
+    ? [Api<B, any, R, E>, ...Api<B, any, R, E>[]]
+    : never
+> = Omit<ApiDefinition, 'endpoints'> &
+  Omit<Injections, 'endpoints'> & {
+    endpoints: ApiDefinition['endpoints'] & UnionToIntersection<Injections[number]['endpoints']>;
+  };

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -67,5 +67,5 @@ export type ApiWithInjectedEndpoints<
     : never
 > = Omit<ApiDefinition, 'endpoints'> &
   Omit<Injections, 'endpoints'> & {
-    endpoints: ApiDefinition['endpoints'] & UnionToIntersection<Injections[number]['endpoints']>;
+    endpoints: ApiDefinition['endpoints'] & Partial<UnionToIntersection<Injections[number]['endpoints']>>;
   };

--- a/src/buildActionMaps.ts
+++ b/src/buildActionMaps.ts
@@ -27,7 +27,7 @@ export interface StartQueryActionCreatorOptions {
   subscriptionOptions?: SubscriptionOptions;
 }
 
-export type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>> = (
+type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>> = (
   arg: QueryArgFrom<D>,
   options?: StartQueryActionCreatorOptions
 ) => ThunkAction<QueryActionCreatorResult<D>, any, any, AnyAction>;
@@ -41,27 +41,7 @@ export type QueryActionCreatorResult<D extends QueryDefinition<any, any, any, an
   updateSubscriptionOptions(options: SubscriptionOptions): void;
 };
 
-export type EndpointActions<Definitions extends EndpointDefinitions> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any>
-    ? StartQueryActionCreator<Definitions[K]>
-    : Definitions[K] extends MutationDefinition<any, any, any, any>
-    ? StartMutationActionCreator<Definitions[K]>
-    : never;
-};
-
-export type QueryActions<Definitions extends EndpointDefinitions> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any>
-    ? StartQueryActionCreator<Definitions[K]>
-    : never;
-};
-
-export type MutationActions<Definitions extends EndpointDefinitions> = {
-  [K in keyof Definitions]: Definitions[K] extends MutationDefinition<any, any, any, any>
-    ? StartMutationActionCreator<Definitions[K]>
-    : never;
-};
-
-export type StartMutationActionCreator<D extends MutationDefinition<any, any, any, any>> = (
+type StartMutationActionCreator<D extends MutationDefinition<any, any, any, any>> = (
   arg: QueryArgFrom<D>,
   options?: {
     /**

--- a/src/buildActionMaps.ts
+++ b/src/buildActionMaps.ts
@@ -2,9 +2,24 @@ import { EndpointDefinitions, QueryDefinition, MutationDefinition, QueryArgFrom 
 import type { QueryThunkArg, MutationThunkArg } from './buildThunks';
 import { AnyAction, AsyncThunk, ThunkAction } from '@reduxjs/toolkit';
 import { MutationSubState, QueryStatus, QuerySubState, SubscriptionOptions } from './apiState';
-import { MutationResultSelectors, QueryResultSelectors } from './buildSelectors';
-import { SliceActions } from './buildSlice';
 import { InternalSerializeQueryArgs } from '.';
+import { Api, ApiEndpointMutation, ApiEndpointQuery } from './apiTypes';
+
+declare module './apiTypes' {
+  export interface ApiEndpointQuery<
+    Definition extends QueryDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    initiate: StartQueryActionCreator<Definition>;
+  }
+
+  export interface ApiEndpointMutation<
+    Definition extends MutationDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    initiate: StartMutationActionCreator<Definition>;
+  }
+}
 
 export interface StartQueryActionCreatorOptions {
   subscribe?: boolean;
@@ -12,7 +27,7 @@ export interface StartQueryActionCreatorOptions {
   subscriptionOptions?: SubscriptionOptions;
 }
 
-export type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any>> = (
+export type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>> = (
   arg: QueryArgFrom<D>,
   options?: StartQueryActionCreatorOptions
 ) => ThunkAction<QueryActionCreatorResult<D>, any, any, AnyAction>;
@@ -71,18 +86,15 @@ export type MutationActionCreatorResult<D extends MutationDefinition<any, any, a
 export function buildActionMaps<Definitions extends EndpointDefinitions, InternalQueryArgs>({
   serializeQueryArgs,
   queryThunk,
-  querySelectors,
   mutationThunk,
-  mutationSelectors,
-  sliceActions: { unsubscribeQueryResult, unsubscribeMutationResult, updateSubscriptionOptions },
+  api,
 }: {
   serializeQueryArgs: InternalSerializeQueryArgs<InternalQueryArgs>;
   queryThunk: AsyncThunk<any, QueryThunkArg<any>, {}>;
-  querySelectors: QueryResultSelectors<Definitions, any>;
   mutationThunk: AsyncThunk<any, MutationThunkArg<any>, {}>;
-  mutationSelectors: MutationResultSelectors<Definitions, any>;
-  sliceActions: SliceActions;
+  api: Api<any, Definitions, any, string>;
 }) {
+  const { unsubscribeQueryResult, unsubscribeMutationResult, updateSubscriptionOptions } = api.internalActions;
   return { buildQueryAction, buildMutationAction };
 
   function buildQueryAction(endpoint: string, definition: QueryDefinition<any, any, any, any>) {
@@ -105,7 +117,9 @@ export function buildActionMaps<Definitions extends EndpointDefinitions, Interna
       const thunkResult = dispatch(thunk);
       const { requestId, abort } = thunkResult;
       assertIsNewRTKPromise(thunkResult);
-      const statePromise = thunkResult.then(() => querySelectors[endpoint](arg)(getState()));
+      const statePromise = thunkResult.then(() =>
+        (api.endpoints[endpoint] as ApiEndpointQuery<any, any>).select(arg)(getState())
+      );
       return Object.assign(statePromise, {
         arg,
         requestId,
@@ -147,7 +161,7 @@ export function buildActionMaps<Definitions extends EndpointDefinitions, Interna
       const { requestId, abort } = thunkResult;
       assertIsNewRTKPromise(thunkResult);
       const statePromise = thunkResult.then(() => {
-        const currentState = mutationSelectors[endpoint](requestId)(getState());
+        const currentState = (api.endpoints[endpoint] as ApiEndpointMutation<any, any>).select(requestId)(getState());
         return currentState as Extract<typeof currentState, { status: QueryStatus.fulfilled | QueryStatus.rejected }>;
       });
       return Object.assign(statePromise, {

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -16,19 +16,30 @@ import {
   QueryArgFrom,
   ResultTypeFrom,
 } from './endpointDefinitions';
-import { QueryResultSelectors, MutationResultSelectors, skipSelector } from './buildSelectors';
-import {
-  QueryActions,
-  MutationActions,
-  QueryActionCreatorResult,
-  MutationActionCreatorResult,
-} from './buildActionMaps';
+import { skipSelector } from './buildSelectors';
+import { QueryActionCreatorResult, MutationActionCreatorResult } from './buildActionMaps';
 import { TS41Hooks } from './ts41Types';
 import { useShallowStableValue } from './utils';
-import { InternalActions } from '.';
+import { Api, ApiEndpointMutation, ApiEndpointQuery } from './apiTypes';
 
 export interface QueryHookOptions extends SubscriptionOptions {
   skip?: boolean;
+}
+
+declare module './apiTypes' {
+  export interface ApiEndpointQuery<
+    Definition extends QueryDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    useQuery: QueryHook<Definition>;
+  }
+
+  export interface ApiEndpointMutation<
+    Definition extends MutationDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    useMutation: MutationHook<Definition>;
+  }
 }
 
 export type QueryHook<D extends QueryDefinition<any, any, any, any>> = (
@@ -71,17 +82,9 @@ export type PrefetchOptions =
     };
 
 export function buildHooks<Definitions extends EndpointDefinitions>({
-  querySelectors,
-  queryActions,
-  mutationSelectors,
-  mutationActions,
-  internalActions,
+  api,
 }: {
-  querySelectors: QueryResultSelectors<Definitions, any>;
-  queryActions: QueryActions<Definitions>;
-  mutationSelectors: MutationResultSelectors<Definitions, any>;
-  mutationActions: MutationActions<Definitions>;
-  internalActions: InternalActions;
+  api: Api<any, Definitions, any, string>;
 }) {
   return { buildQueryHook, buildMutationHook, usePrefetch };
 
@@ -94,13 +97,17 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
     return useCallback(
       (arg: any, options?: PrefetchOptions) =>
-        dispatch(internalActions.prefetchThunk(endpointName, arg, { ...stableDefaultOptions, ...options })),
+        dispatch(api.internalActions.prefetchThunk(endpointName, arg, { ...stableDefaultOptions, ...options })),
       [endpointName, dispatch, stableDefaultOptions]
     );
   }
 
   function buildQueryHook(name: string): QueryHook<any> {
     return (arg: any, { skip = false, pollingInterval = 0 } = {}) => {
+      const { select, initiate } = api.endpoints[name] as ApiEndpointQuery<
+        QueryDefinition<any, any, any, any, any>,
+        Definitions
+      >;
       const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
 
       const stableArg = useShallowStableValue(arg);
@@ -108,29 +115,24 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const lastData = useRef<ResultTypeFrom<Definitions[string]> | undefined>();
       const promiseRef = useRef<QueryActionCreatorResult<any>>();
 
-      const buildQuerySelector = querySelectors[name];
-      const querySelector = useMemo(() => buildQuerySelector(skip ? skipSelector : stableArg), [
-        skip,
-        stableArg,
-        buildQuerySelector,
-      ]);
+      const querySelector = useMemo(() => select(skip ? skipSelector : stableArg), [select, skip, stableArg]);
       const currentState = useSelector(querySelector);
 
       useEffect(() => {
         if (skip) {
           return;
         }
-        const startQuery = queryActions[name];
+
         const lastPromise = promiseRef.current;
         if (lastPromise && lastPromise.arg === stableArg) {
           // arg did not change, but options did probably, update them
           lastPromise.updateSubscriptionOptions({ pollingInterval });
         } else {
           if (lastPromise) lastPromise.unsubscribe();
-          const promise = dispatch(startQuery(stableArg, { subscriptionOptions: { pollingInterval } }));
+          const promise = dispatch(initiate(stableArg, { subscriptionOptions: { pollingInterval } }));
           promiseRef.current = promise;
         }
-      }, [stableArg, dispatch, skip, pollingInterval]);
+      }, [stableArg, dispatch, skip, pollingInterval, initiate]);
 
       useEffect(() => {
         return () => void promiseRef.current?.unsubscribe();
@@ -165,6 +167,10 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
   function buildMutationHook(name: string): MutationHook<any> {
     return () => {
+      const { select, initiate } = api.endpoints[name] as ApiEndpointMutation<
+        MutationDefinition<any, any, any, any, any>,
+        Definitions
+      >;
       const dispatch = useDispatch<ThunkDispatch<any, any, AnyAction>>();
       const [requestId, setRequestId] = useState<string>();
 
@@ -177,20 +183,16 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           let promise: MutationActionCreatorResult<any>;
           batch(() => {
             if (promiseRef.current) promiseRef.current.unsubscribe();
-            promise = dispatch(mutationActions[name](args));
+            promise = dispatch(initiate(args));
             promiseRef.current = promise;
             setRequestId(promise.requestId);
           });
           return promise!;
         },
-        [dispatch]
+        [dispatch, initiate]
       );
 
-      const buildMutationSelector = mutationSelectors[name];
-      const mutationSelector = useMemo(() => buildMutationSelector(requestId || skipSelector), [
-        requestId,
-        buildMutationSelector,
-      ]);
+      const mutationSelector = useMemo(() => select(requestId || skipSelector), [requestId, select]);
       const currentState = useSelector(mutationSelector);
 
       return useMemo(() => [triggerMutation, currentState], [triggerMutation, currentState]);

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -18,11 +18,10 @@ import {
 } from './endpointDefinitions';
 import { skipSelector } from './buildSelectors';
 import { QueryActionCreatorResult, MutationActionCreatorResult } from './buildActionMaps';
-import { TS41Hooks } from './ts41Types';
 import { useShallowStableValue } from './utils';
 import { Api, ApiEndpointMutation, ApiEndpointQuery } from './apiTypes';
 
-export interface QueryHookOptions extends SubscriptionOptions {
+interface QueryHookOptions extends SubscriptionOptions {
   skip?: boolean;
 }
 
@@ -50,7 +49,7 @@ export type QueryHook<D extends QueryDefinition<any, any, any, any>> = (
 type AdditionalQueryStatusFlags = {
   isFetching: boolean;
 };
-export type QueryHookResult<D extends QueryDefinition<any, any, any, any>> = QuerySubState<D> &
+type QueryHookResult<D extends QueryDefinition<any, any, any, any>> = QuerySubState<D> &
   RequestStatusFlags &
   AdditionalQueryStatusFlags &
   Pick<QueryActionCreatorResult<D>, 'refetch'>;
@@ -61,19 +60,6 @@ export type MutationHook<D extends MutationDefinition<any, any, any, any>> = () 
   ) => Promise<Extract<MutationSubState<D>, { status: QueryStatus.fulfilled | QueryStatus.rejected }>>,
   MutationSubState<D> & RequestStatusFlags
 ];
-
-export type Hooks<Definitions extends EndpointDefinitions> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any>
-    ? {
-        useQuery: QueryHook<Definitions[K]>;
-      }
-    : Definitions[K] extends MutationDefinition<any, any, any, any>
-    ? {
-        useMutation: MutationHook<Definitions[K]>;
-      }
-    : never;
-} &
-  TS41Hooks<Definitions>;
 
 export type PrefetchOptions =
   | { force?: boolean }

--- a/src/buildSelectors.ts
+++ b/src/buildSelectors.ts
@@ -7,7 +7,14 @@ import {
   getRequestStatusFlags,
   RequestStatusFlags,
 } from './apiState';
-import { EndpointDefinitions, QueryDefinition, MutationDefinition, QueryArgFrom } from './endpointDefinitions';
+import {
+  EndpointDefinitions,
+  QueryDefinition,
+  MutationDefinition,
+  QueryArgFrom,
+  EntityTypesFrom,
+  ReducerPathFrom,
+} from './endpointDefinitions';
 import type { InternalState } from './buildSlice';
 import { InternalSerializeQueryArgs } from '.';
 
@@ -20,6 +27,28 @@ export type Selectors<Definitions extends EndpointDefinitions, RootState> = {
     ? MutationResultSelector<Definitions[K], RootState>
     : never;
 };
+
+declare module './apiTypes' {
+  export interface ApiEndpointQuery<
+    Definition extends QueryDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    select: QueryResultSelector<
+      Definition,
+      _RootState<Definitions, EntityTypesFrom<Definition>, ReducerPathFrom<Definition>>
+    >;
+  }
+
+  export interface ApiEndpointMutation<
+    Definition extends MutationDefinition<any, any, any, any, any>,
+    Definitions extends EndpointDefinitions
+  > {
+    select: MutationResultSelector<
+      Definition,
+      _RootState<Definitions, EntityTypesFrom<Definition>, ReducerPathFrom<Definition>>
+    >;
+  }
+}
 
 export type QueryResultSelectors<Definitions extends EndpointDefinitions, RootState> = {
   [K in keyof Definitions]: Definitions[K] extends QueryDefinition<infer QueryArg, any, any, infer ResultType>

--- a/src/buildSelectors.ts
+++ b/src/buildSelectors.ts
@@ -20,14 +20,6 @@ import { InternalSerializeQueryArgs } from '.';
 
 export const skipSelector = Symbol('skip selector');
 
-export type Selectors<Definitions extends EndpointDefinitions, RootState> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any>
-    ? QueryResultSelector<Definitions[K], RootState>
-    : Definitions[K] extends MutationDefinition<any, any, any, any>
-    ? MutationResultSelector<Definitions[K], RootState>
-    : never;
-};
-
 declare module './apiTypes' {
   export interface ApiEndpointQuery<
     Definition extends QueryDefinition<any, any, any, any, any>,
@@ -50,26 +42,11 @@ declare module './apiTypes' {
   }
 }
 
-export type QueryResultSelectors<Definitions extends EndpointDefinitions, RootState> = {
-  [K in keyof Definitions]: Definitions[K] extends QueryDefinition<infer QueryArg, any, any, infer ResultType>
-    ? (
-        queryArg: QueryArg | typeof skipSelector
-      ) => (state: RootState) => QuerySubState<Definitions[K]> & RequestStatusFlags
-    : never;
-};
-
-export type MutationResultSelectors<Definitions extends EndpointDefinitions, RootState> = {
-  [K in keyof Definitions]: Definitions[K] extends MutationDefinition<any, any, any, infer ResultType>
-    ? (
-        requestId: string | typeof skipSelector
-      ) => (state: RootState) => MutationSubState<Definitions[K]> & RequestStatusFlags
-    : never;
-};
-
-export type QueryResultSelector<Definition extends QueryDefinition<any, any, any, any>, RootState> = (
+type QueryResultSelector<Definition extends QueryDefinition<any, any, any, any>, RootState> = (
   queryArg: QueryArgFrom<Definition> | typeof skipSelector
 ) => (state: RootState) => QuerySubState<Definition> & RequestStatusFlags;
-export type MutationResultSelector<Definition extends MutationDefinition<any, any, any, any>, RootState> = (
+
+type MutationResultSelector<Definition extends MutationDefinition<any, any, any, any>, RootState> = (
   requestId: string | typeof skipSelector
 ) => (state: RootState) => MutationSubState<Definition> & RequestStatusFlags;
 

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -17,14 +17,14 @@ export enum DefinitionType {
   mutation = 'mutation',
 }
 
-export type GetResultDescriptionFn<EntityTypes extends string, ResultType, QueryArg> = (
+type GetResultDescriptionFn<EntityTypes extends string, ResultType, QueryArg> = (
   result: ResultType,
   arg: QueryArg
 ) => ReadonlyArray<EntityDescription<EntityTypes>>;
 
 export type FullEntityDescription<EntityType> = { type: EntityType; id?: number | string };
-export type EntityDescription<EntityType> = EntityType | FullEntityDescription<EntityType>;
-export type ResultDescription<EntityTypes extends string, ResultType, QueryArg> =
+type EntityDescription<EntityType> = EntityType | FullEntityDescription<EntityType>;
+type ResultDescription<EntityTypes extends string, ResultType, QueryArg> =
   | ReadonlyArray<EntityDescription<EntityTypes>>
   | GetResultDescriptionFn<EntityTypes, ResultType, QueryArg>;
 

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -32,7 +32,8 @@ export interface QueryDefinition<
   QueryArg,
   BaseQuery extends (arg: any, ...args: any[]) => any,
   EntityTypes extends string,
-  ResultType
+  ResultType,
+  _ReducerPath extends string = string
 > extends BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> {
   type: DefinitionType.query;
   provides?: ResultDescription<EntityTypes, ResultType, QueryArg>;
@@ -67,10 +68,11 @@ export type EndpointDefinition<
   QueryArg,
   BaseQuery extends (arg: any, ...args: any[]) => any,
   EntityTypes extends string,
-  ResultType
+  ResultType,
+  ReducerPath extends string = string
 > =
-  | QueryDefinition<QueryArg, BaseQuery, EntityTypes, ResultType>
-  | MutationDefinition<QueryArg, BaseQuery, EntityTypes, ResultType>;
+  | QueryDefinition<QueryArg, BaseQuery, EntityTypes, ResultType, ReducerPath>
+  | MutationDefinition<QueryArg, BaseQuery, EntityTypes, ResultType, ReducerPath>;
 
 export type EndpointDefinitions = Record<string, EndpointDefinition<any, any, any, any>>;
 
@@ -135,4 +137,22 @@ export type ResultTypeFrom<D extends BaseEndpointDefinition<any, any, any>> = D 
   infer RT
 >
   ? RT
+  : unknown;
+
+export type ReducerPathFrom<D extends EndpointDefinition<any, any, any, any>> = D extends EndpointDefinition<
+  any,
+  any,
+  any,
+  infer RP
+>
+  ? RP
+  : unknown;
+
+export type EntityTypesFrom<D extends EndpointDefinition<any, any, any, any>> = D extends EndpointDefinition<
+  any,
+  any,
+  infer RP,
+  any
+>
+  ? RP
   : unknown;

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -1,17 +1,5 @@
-import { EndpointDefinition, MutationDefinition, QueryDefinition } from './endpointDefinitions';
-
 export type Id<T> = { [K in keyof T]: T[K] } & {};
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
-
-export type SwitchEndpoint<
-  D extends EndpointDefinition<any, any, any, any>,
-  QueryCase,
-  MutationCase
-> = D extends QueryDefinition<any, any, any, any>
-  ? QueryCase
-  : D extends MutationDefinition<any, any, any, any>
-  ? MutationCase
-  : never;
 
 export function assertCast<T>(v: any): asserts v is T {}
 

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -25,7 +25,7 @@ describe('hooks tests', () => {
     function User() {
       const [value, setValue] = React.useState(0);
 
-      const { isFetching } = api.hooks.getUser.useQuery(1, { skip: value < 1 });
+      const { isFetching } = api.endpoints.getUser.useQuery(1, { skip: value < 1 });
 
       return (
         <div>
@@ -51,7 +51,7 @@ describe('hooks tests', () => {
     function User() {
       const [value, setValue] = React.useState(0);
 
-      const { isLoading, refetch } = api.hooks.getUser.useQuery(2, { skip: value < 1 });
+      const { isLoading, refetch } = api.endpoints.getUser.useQuery(2, { skip: value < 1 });
       refetchMe = refetch;
       return (
         <div>
@@ -83,7 +83,7 @@ describe('hooks tests', () => {
     function User() {
       const [value, setValue] = React.useState(0);
 
-      const { isLoading, isFetching, refetch } = api.hooks.getUser.useQuery(22, { skip: value < 1 });
+      const { isLoading, isFetching, refetch } = api.endpoints.getUser.useQuery(22, { skip: value < 1 });
       refetchMe = refetch;
       return (
         <div>
@@ -136,7 +136,7 @@ describe('hooks tests', () => {
 
   test('useMutation hook sets and unsets the `isLoading` flag when running', async () => {
     function User() {
-      const [updateUser, { isLoading }] = api.hooks.updateUser.useMutation();
+      const [updateUser, { isLoading }] = api.endpoints.updateUser.useMutation();
 
       return (
         <div>
@@ -158,7 +158,7 @@ describe('hooks tests', () => {
     const result = { name: 'Banana' };
 
     function User() {
-      const [updateUser, { data }] = api.hooks.updateUser.useMutation();
+      const [updateUser, { data }] = api.endpoints.updateUser.useMutation();
 
       return (
         <div>
@@ -178,7 +178,7 @@ describe('hooks tests', () => {
     const { usePrefetch } = api;
     const USER_ID = 4;
     function User() {
-      const { isFetching } = api.hooks.getUser.useQuery(USER_ID);
+      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
       const prefetchUser = usePrefetch('getUser', { force: true });
 
       return (
@@ -198,7 +198,7 @@ describe('hooks tests', () => {
 
     userEvent.hover(getByTestId('highPriority'));
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -215,7 +215,7 @@ describe('hooks tests', () => {
 
     await waitMs(DEFAULT_DELAY_MS + 100);
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -237,7 +237,7 @@ describe('hooks tests', () => {
 
     function User() {
       // Load the initial query
-      const { isFetching } = api.hooks.getUser.useQuery(USER_ID);
+      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
       const prefetchUser = usePrefetch('getUser', { force: false });
 
       return (
@@ -257,7 +257,7 @@ describe('hooks tests', () => {
     // Try to prefetch what we just loaded
     userEvent.hover(getByTestId('lowPriority'));
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -274,7 +274,7 @@ describe('hooks tests', () => {
 
     await waitMs();
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -296,7 +296,7 @@ describe('hooks tests', () => {
 
     function User() {
       // Load the initial query
-      const { isFetching } = api.hooks.getUser.useQuery(USER_ID);
+      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
       const prefetchUser = usePrefetch('getUser', { ifOlderThan: 0.2 });
 
       return (
@@ -318,7 +318,7 @@ describe('hooks tests', () => {
 
     // This should run the query being that we're past the threshold
     userEvent.hover(getByTestId('lowPriority'));
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -335,7 +335,7 @@ describe('hooks tests', () => {
 
     await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
       endpoint: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
@@ -357,7 +357,7 @@ describe('hooks tests', () => {
 
     function User() {
       // Load the initial query
-      const { isFetching } = api.hooks.getUser.useQuery(USER_ID);
+      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
       const prefetchUser = usePrefetch('getUser', { ifOlderThan: 10 });
 
       return (
@@ -376,11 +376,11 @@ describe('hooks tests', () => {
     await waitMs();
 
     // Get a snapshot of the last result
-    const latestQueryData = api.selectors.getUser(USER_ID)(storeRef.store.getState());
+    const latestQueryData = api.endpoints.getUser.select(USER_ID)(storeRef.store.getState());
 
     userEvent.hover(getByTestId('lowPriority'));
     //  Serve up the result from the cache being that the condition wasn't met
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual(latestQueryData);
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual(latestQueryData);
   });
 
   test('usePrefetch executes a query even if conditions fail when the cache is empty', async () => {
@@ -403,7 +403,7 @@ describe('hooks tests', () => {
 
     userEvent.hover(getByTestId('lowPriority'));
 
-    expect(api.selectors.getUser(USER_ID)(storeRef.store.getState())).toEqual({
+    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       endpoint: 'getUser',
       internalQueryArgs: USER_ID,
       isError: false,

--- a/test/buildThunks.test.tsx
+++ b/test/buildThunks.test.tsx
@@ -16,6 +16,7 @@ test('handles a non-async baseQuery without error', async () => {
       }),
     }),
   });
+  const { getUser } = api.endpoints;
   const store = configureStore({
     reducer: {
       [api.reducerPath]: api.reducer,
@@ -23,14 +24,14 @@ test('handles a non-async baseQuery without error', async () => {
     middleware: (gDM) => gDM().concat(api.middleware),
   });
 
-  const promise = store.dispatch(api.actions.getUser(1));
+  const promise = store.dispatch(getUser.initiate(1));
   const { data } = await promise;
 
   expect(data).toEqual({
     url: 'user/1',
   });
 
-  const storeResult = api.selectors.getUser(1)(store.getState());
+  const storeResult = getUser.select(1)(store.getState());
   expect(storeResult).toEqual({
     data: {
       url: 'user/1',
@@ -60,16 +61,17 @@ describe('re-triggering behavior on arg change', () => {
       }),
     }),
   });
+  const { getUser } = api.endpoints;
   const store = configureStore({
     reducer: { [api.reducerPath]: api.reducer },
     middleware: (gDM) => gDM().concat(api.middleware),
   });
 
-  const spy = jest.spyOn(api.actions, 'getUser');
+  const spy = jest.spyOn(getUser, 'initiate');
   beforeEach(() => void spy.mockClear());
 
   test('re-trigger on literal value change', async () => {
-    const { result, rerender, waitForNextUpdate } = renderHook((props) => api.hooks.getUser.useQuery(props), {
+    const { result, rerender, waitForNextUpdate } = renderHook((props) => getUser.useQuery(props), {
       wrapper: withProvider(store),
       initialProps: 5,
     });
@@ -99,7 +101,7 @@ describe('re-triggering behavior on arg change', () => {
   });
 
   test('only re-trigger on shallow-equal arg change', async () => {
-    const { result, rerender, waitForNextUpdate } = renderHook((props) => api.hooks.getUser.useQuery(props), {
+    const { result, rerender, waitForNextUpdate } = renderHook((props) => getUser.useQuery(props), {
       wrapper: withProvider(store),
       initialProps: { name: 'Bob', likes: 'iceCream' },
     });
@@ -129,7 +131,7 @@ describe('re-triggering behavior on arg change', () => {
   });
 
   test('re-trigger every time on deeper value changes', async () => {
-    const { result, rerender, waitForNextUpdate } = renderHook((props) => api.hooks.getUser.useQuery(props), {
+    const { result, rerender, waitForNextUpdate } = renderHook((props) => getUser.useQuery(props), {
       wrapper: withProvider(store),
       initialProps: { person: { name: 'Tim' } },
     });
@@ -150,7 +152,7 @@ describe('re-triggering behavior on arg change', () => {
   });
 
   test('do not re-trigger if the order of keys change while maintaining the same values', async () => {
-    const { result, rerender, waitForNextUpdate } = renderHook((props) => api.hooks.getUser.useQuery(props), {
+    const { result, rerender, waitForNextUpdate } = renderHook((props) => getUser.useQuery(props), {
       wrapper: withProvider(store),
       initialProps: { name: 'Tim', likes: 'Bananas' },
     });

--- a/test/cleanup.test.tsx
+++ b/test/cleanup.test.tsx
@@ -19,18 +19,18 @@ let getSubStateA = () => storeRef.store.getState().api.queries['a/""'];
 let getSubStateB = () => storeRef.store.getState().api.queries['b/""'];
 
 function UsingA() {
-  api.hooks.useAQuery();
+  api.useAQuery();
   return <></>;
 }
 
 function UsingB() {
-  api.hooks.useBQuery();
+  api.useBQuery();
   return <></>;
 }
 
 function UsingAB() {
-  api.hooks.useAQuery();
-  api.hooks.useBQuery();
+  api.useAQuery();
+  api.useBQuery();
   return <></>;
 }
 

--- a/test/createApi.test.ts
+++ b/test/createApi.test.ts
@@ -124,7 +124,7 @@ describe('wrong entityTypes log errors', () => {
     spy.mockRestore();
   });
 
-  test.each<[keyof typeof api.actions, boolean?]>([
+  test.each<[keyof typeof api.endpoints, boolean?]>([
     ['provideNothing', false],
     ['provideTypeString', false],
     ['provideTypeWithId', false],
@@ -141,12 +141,12 @@ describe('wrong entityTypes log errors', () => {
     ['invalidateWrongTypeWithIdAndCallback', true],
   ])(`endpoint %s should log an error? %s`, async (endpoint, shouldError) => {
     // @ts-ignore
-    store.dispatch(api.actions[endpoint]());
+    store.dispatch(api.endpoints[endpoint].initiate());
     let result: { status: string };
     do {
       await waitMs(5);
       // @ts-ignore
-      result = api.selectors[endpoint]()(store.getState());
+      result = api.endpoints[endpoint].select()(store.getState());
     } while (result.status === 'pending');
 
     if (shouldError) {

--- a/test/example.test.disabled.tsx
+++ b/test/example.test.disabled.tsx
@@ -93,7 +93,7 @@ describe('examples', () => {
     }
 
     {
-      const { result, waitForNextUpdate } = renderHook(() => api.hooks.useGetUserQuery('5'), { wrapper: Wrapper });
+      const { result, waitForNextUpdate } = renderHook(() => api.endpoints.useGetUserQuery('5'), { wrapper: Wrapper });
 
       expect(result.current).toEqual({
         endpoint: 'getUser',
@@ -121,7 +121,7 @@ describe('examples', () => {
     }
 
     {
-      const { result, waitForNextUpdate } = renderHook(() => api.hooks.updateUser.useMutation(), {
+      const { result, waitForNextUpdate } = renderHook(() => api.endpoints.updateUser.useMutation(), {
         wrapper: Wrapper,
       });
 

--- a/test/optimisticUpdates.test.tsx
+++ b/test/optimisticUpdates.test.tsx
@@ -65,7 +65,7 @@ describe('basic lifecycle', () => {
   });
 
   test('success', async () => {
-    const { result } = renderHook(() => extendedApi.hooks.useTestMutation(), {
+    const { result } = renderHook(() => extendedApi.useTestMutation(), {
       wrapper: storeRef.wrapper,
     });
 
@@ -85,7 +85,7 @@ describe('basic lifecycle', () => {
   });
 
   test('error', async () => {
-    const { result } = renderHook(() => extendedApi.hooks.useTestMutation(), {
+    const { result } = renderHook(() => extendedApi.useTestMutation(), {
       wrapper: storeRef.wrapper,
     });
 
@@ -109,7 +109,7 @@ describe('updateQueryResult', () => {
   test('updates cache values, can apply inverse patch', async () => {
     baseQuery.mockResolvedValueOnce({ id: '3', title: 'All about cheese.', contents: 'TODO' });
 
-    const { result } = renderHook(() => api.hooks.usePostQuery('3'), {
+    const { result } = renderHook(() => api.usePostQuery('3'), {
       wrapper: storeRef.wrapper,
     });
     await hookWaitFor(() => expect(result.current.isSuccess).toBeTruthy());
@@ -144,7 +144,7 @@ describe('updateQueryResult', () => {
   test('does not update non-existing values', async () => {
     baseQuery.mockResolvedValueOnce({ id: '3', title: 'All about cheese.', contents: 'TODO' });
 
-    const { result } = renderHook(() => api.hooks.usePostQuery('3'), {
+    const { result } = renderHook(() => api.usePostQuery('3'), {
       wrapper: storeRef.wrapper,
     });
     await hookWaitFor(() => expect(result.current.isSuccess).toBeTruthy());
@@ -178,8 +178,8 @@ describe('full integration', () => {
       .mockResolvedValueOnce({ id: '3', title: 'Meanwhile, this changed server-side.', contents: 'Delicious cheese!' });
     const { result } = renderHook(
       () => ({
-        query: api.hooks.usePostQuery('3'),
-        mutation: api.hooks.useUpdatePostMutation(),
+        query: api.usePostQuery('3'),
+        mutation: api.useUpdatePostMutation(),
       }),
       {
         wrapper: storeRef.wrapper,
@@ -212,8 +212,8 @@ describe('full integration', () => {
 
     const { result } = renderHook(
       () => ({
-        query: api.hooks.usePostQuery('3'),
-        mutation: api.hooks.useUpdatePostMutation(),
+        query: api.usePostQuery('3'),
+        mutation: api.useUpdatePostMutation(),
       }),
       {
         wrapper: storeRef.wrapper,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8616,6 +8616,14 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-unused-exports@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ts-unused-exports/-/ts-unused-exports-7.0.0.tgz#e8d228b03c9d8f07d3655fe768d890d5d5512686"
+  integrity sha512-KSFhNUNt5I6jddGdp2osc6MuxOdgmtNwRLeQ9LeDuoItR1qcRtG8May0a8OShyWxpMGJGaN9WSDtqY1N4u7SIA==
+  dependencies:
+    chalk "^3.0.0"
+    tsconfig-paths "^3.9.0"
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
this changes the api shape from
```ts
{
 hooks: { login: { useQuery }, useLoginQuery },
 actions: { login },
 matchers: { login: { fulfilled, etc }} // TODO ;)
 selectors: { login }
}
```
towards
```ts
{
 useLoginQuery,
 endpoints: { login: { useQuery, initiate, selector, matchFulfilled, matchRejected, matchPending } }
}
```