### PR TITLE
Switch RTK to be a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
     }
   ],
   "dependencies": {
-    "@reduxjs/toolkit": "^1.5.0",
     "immer": ">=8.0.0"
   },
   "peerDependencies": {
+    "@reduxjs/toolkit": "^1.5.0",
     "react": "^16.14.0 || ^17.0.0",
     "react-dom": "^16.14.0 || ^17.0.0",
     "react-redux": "^7.2.1"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     }
   },
   "devDependencies": {
+    "@reduxjs/toolkit": "^1.5.0",
     "@size-limit/preset-small-lib": "^4.6.0",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^3.4.2",


### PR DESCRIPTION
Since this is supposed to be an addon to RTK, we need RTK to be a peerDep instead of a dep.

This drops the size noticeably.

dep:

```
  dist/rtk-query.cjs.production.min.js
  Size limit: 25 KB
  Size:       20.61 KB with all dependencies, minified and gzipped

  dist/rtk-query.esm.js
  Size limit: 25 KB
  Size:       17.01 KB with all dependencies, minified and gzipped
```

peerDep:

```
  dist/rtk-query.cjs.production.min.js
  Size limit: 25 KB
  Size:       14.11 KB with all dependencies, minified and gzipped

  dist/rtk-query.esm.js
  Size limit: 25 KB
  Size:       12.5 KB with all dependencies, minified and gzipped
```