### PR TITLE
Implement refetchOnMountOrArgChange

### DIFF
--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -19,7 +19,8 @@ The main point where you will define a service to use in your application.
   entityTypes?: readonly EntityTypes[];
   reducerPath?: ReducerPath;
   serializeQueryArgs?: SerializeQueryArgs<InternalQueryArgs>;
-  keepUnusedDataFor?: number;
+  keepUnusedDataFor?: number; // value is in seconds
+  refetchOnMount?: boolean | number; // value is in seconds
 ```
 
 ### `baseQuery`
@@ -203,6 +204,22 @@ export const api = createApi({
 });
 ```
 
+### `keepUnusedDataFor`
+
+Defaults to `60` _(this value is in seconds)_. This is how long RTK Query will keep your data cached for **after** the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
+
+### `refetchOnMount`
+
+Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
+
+- `false` - Will not cause a query to be performed _unless_ it does not exist yet.
+- `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
+- `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
+
+:::note
+You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnMount` to each individual hook call or when dispatching the [`initiate`](#initiate) action.
+:::
+
 ## Return value
 
 - [`reducerPath`](#reducerpath)
@@ -364,7 +381,3 @@ Both of these utils are currently used for [optimistic updates](../concepts/opti
 ### `injectEndpoints`
 
 See [Code Splitting](../concepts/code-splitting)
-
-### `keepUnusedDataFor`
-
-Defaults to `60` _(this value is in seconds)_. This is how long RTK Query will keep your data cached for **after** the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -20,7 +20,7 @@ The main point where you will define a service to use in your application.
   reducerPath?: ReducerPath;
   serializeQueryArgs?: SerializeQueryArgs<InternalQueryArgs>;
   keepUnusedDataFor?: number; // value is in seconds
-  refetchOnMount?: boolean | number; // value is in seconds
+  refetchOnMountOrArgChange?: boolean | number; // value is in seconds
 ```
 
 ### `baseQuery`
@@ -208,7 +208,7 @@ export const api = createApi({
 
 Defaults to `60` _(this value is in seconds)_. This is how long RTK Query will keep your data cached for **after** the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
 
-### `refetchOnMount`
+### `refetchOnMountOrArgChange`
 
 Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
 
@@ -216,8 +216,10 @@ Defaults to `false`. This setting allows you to control whether RTK Query will o
 - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
 - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
 
+If you specify this option as well as with `skip: true`, this **will not be evaluated** until `skip` is false.
+
 :::note
-You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnMount` to each individual hook call or when dispatching the [`initiate`](#initiate) action.
+You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnMountOrArgChange` to each individual hook call or when dispatching the [`initiate`](#initiate) action.
 :::
 
 ## Return value

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -19,11 +19,21 @@ If you're using React Hooks, RTK Query does a few additional things for you. The
 
 Hooks are automatically generated based on the name of the `endpoint` in the service definition. An endpoint field with `getPost: builder.query()` will generate a hook named `useGetPostQuery`.
 
+#### Query Hook Options
+
+- [pollingInterval?](./polling) - Defaults to `0`
+- [refetchOnMount?](../api/createApi#refetchonmount) - Defaults to `false`. Will override any value that was specified in `createApi`.
+- [skip?](./conditional-fetching) - Defaults to `false`
+
 Here is an example of a `PostDetail` component:
 
 ```ts title="Example"
 export const PostDetail = ({ id }: { id: string }) => {
-  const { data: post, isFetching, isLoading } = useGetPostQuery(id, { pollingInterval: 3000 });
+  const { data: post, isFetching, isLoading } = useGetPostQuery(id, {
+    pollingInterval: 3000,
+    refetchOnMount: true,
+    skip: false,
+  });
 
   if (isLoading) return <div>Loading...</div>;
   if (!post) return <div>Missing post!</div>;

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -22,7 +22,7 @@ Hooks are automatically generated based on the name of the `endpoint` in the ser
 #### Query Hook Options
 
 - [pollingInterval?](./polling) - Defaults to `0`
-- [refetchOnMount?](../api/createApi#refetchonmount) - Defaults to `false`. Will override any value that was specified in `createApi`.
+- [refetchOnMountOrArgChange?](../api/createApi#refetchOnMountOrArgChange) - Defaults to `false`. Will override any value that was specified in `createApi`.
 - [skip?](./conditional-fetching) - Defaults to `false`
 
 Here is an example of a `PostDetail` component:
@@ -31,7 +31,7 @@ Here is an example of a `PostDetail` component:
 export const PostDetail = ({ id }: { id: string }) => {
   const { data: post, isFetching, isLoading } = useGetPostQuery(id, {
     pollingInterval: 3000,
-    refetchOnMount: true,
+    refetchOnMountOrArgChange: true,
     skip: false,
   });
 

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -80,7 +80,7 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const [pollingInterval, setPollingInterval] = React.useState(0);
   const { data, refetch, isFetching } = useGetTimeQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
-    refetchOnMount: true,
+    refetchOnMount: 10,
   });
 
   return (

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -80,6 +80,7 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const [pollingInterval, setPollingInterval] = React.useState(0);
   const { data, refetch, isFetching } = useGetTimeQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
+    refetchOnMount: true,
   });
 
   return (

--- a/examples/react/src/features/time/TimeList.tsx
+++ b/examples/react/src/features/time/TimeList.tsx
@@ -80,7 +80,7 @@ const TimeDisplay = ({ offset, label }: { offset: string; label: string }) => {
   const [pollingInterval, setPollingInterval] = React.useState(0);
   const { data, refetch, isFetching } = useGetTimeQuery(offset, {
     pollingInterval: canPoll ? pollingInterval : 0,
-    refetchOnMount: 10,
+    refetchOnMountOrArgChange: 10,
   });
 
   return (

--- a/src/buildActionMaps.ts
+++ b/src/buildActionMaps.ts
@@ -25,7 +25,7 @@ export interface StartQueryActionCreatorOptions {
   subscribe?: boolean;
   forceRefetch?: boolean;
   subscriptionOptions?: SubscriptionOptions;
-  refetchOnMount?: boolean | number;
+  refetchOnMountOrArgChange?: boolean | number;
 }
 
 type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>> = (
@@ -81,14 +81,14 @@ export function buildActionMaps<Definitions extends EndpointDefinitions, Interna
   function buildQueryAction(endpoint: string, definition: QueryDefinition<any, any, any, any>) {
     const queryAction: StartQueryActionCreator<any> = (
       arg,
-      { subscribe = true, forceRefetch = false, refetchOnMount = false, subscriptionOptions } = {}
+      { subscribe = true, forceRefetch = false, refetchOnMountOrArgChange = false, subscriptionOptions } = {}
     ) => (dispatch, getState) => {
       const internalQueryArgs = definition.query(arg);
       const queryCacheKey = serializeQueryArgs({ queryArgs: arg, internalQueryArgs, endpoint });
       const thunk = queryThunk({
         subscribe,
         forceRefetch,
-        refetchOnMount,
+        refetchOnMountOrArgChange,
         subscriptionOptions,
         endpoint,
         originalArgs: arg,

--- a/src/buildActionMaps.ts
+++ b/src/buildActionMaps.ts
@@ -25,6 +25,7 @@ export interface StartQueryActionCreatorOptions {
   subscribe?: boolean;
   forceRefetch?: boolean;
   subscriptionOptions?: SubscriptionOptions;
+  refetchOnMount?: boolean | number;
 }
 
 type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>> = (
@@ -80,13 +81,14 @@ export function buildActionMaps<Definitions extends EndpointDefinitions, Interna
   function buildQueryAction(endpoint: string, definition: QueryDefinition<any, any, any, any>) {
     const queryAction: StartQueryActionCreator<any> = (
       arg,
-      { subscribe = true, forceRefetch = false, subscriptionOptions } = {}
+      { subscribe = true, forceRefetch = false, refetchOnMount = false, subscriptionOptions } = {}
     ) => (dispatch, getState) => {
       const internalQueryArgs = definition.query(arg);
       const queryCacheKey = serializeQueryArgs({ queryArgs: arg, internalQueryArgs, endpoint });
       const thunk = queryThunk({
         subscribe,
         forceRefetch,
+        refetchOnMount,
         subscriptionOptions,
         endpoint,
         originalArgs: arg,

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -24,7 +24,7 @@ import { Id, Override } from './tsHelpers';
 
 interface QueryHookOptions extends SubscriptionOptions {
   skip?: boolean;
-  refetchOnMount?: boolean | number;
+  refetchOnMountOrArgChange?: boolean | number;
 }
 
 declare module './apiTypes' {
@@ -118,7 +118,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   }
 
   function buildQueryHook(name: string): QueryHook<any> {
-    return (arg: any, { refetchOnMount = false, skip = false, pollingInterval = 0 } = {}) => {
+    return (arg: any, { refetchOnMountOrArgChange = false, skip = false, pollingInterval = 0 } = {}) => {
       const { select, initiate } = api.endpoints[name] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
@@ -144,10 +144,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           lastPromise.updateSubscriptionOptions({ pollingInterval });
         } else {
           if (lastPromise) lastPromise.unsubscribe();
-          const promise = dispatch(initiate(stableArg, { subscriptionOptions: { pollingInterval }, refetchOnMount }));
+          const promise = dispatch(
+            initiate(stableArg, { subscriptionOptions: { pollingInterval }, refetchOnMountOrArgChange })
+          );
           promiseRef.current = promise;
         }
-      }, [stableArg, dispatch, skip, pollingInterval, refetchOnMount, initiate]);
+      }, [stableArg, dispatch, skip, pollingInterval, refetchOnMountOrArgChange, initiate]);
 
       useEffect(() => {
         return () => void promiseRef.current?.unsubscribe();

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -24,7 +24,7 @@ import { Id, Override } from './tsHelpers';
 
 interface QueryHookOptions extends SubscriptionOptions {
   skip?: boolean;
-  refetchOnMount?: boolean;
+  refetchOnMount?: boolean | number;
 }
 
 declare module './apiTypes' {
@@ -144,9 +144,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           lastPromise.updateSubscriptionOptions({ pollingInterval });
         } else {
           if (lastPromise) lastPromise.unsubscribe();
-          const promise = dispatch(
-            initiate(stableArg, { subscriptionOptions: { pollingInterval }, forceRefetch: refetchOnMount })
-          );
+          const promise = dispatch(initiate(stableArg, { subscriptionOptions: { pollingInterval }, refetchOnMount }));
           promiseRef.current = promise;
         }
       }, [stableArg, dispatch, skip, pollingInterval, refetchOnMount, initiate]);

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -24,6 +24,7 @@ import { Id, Override } from './tsHelpers';
 
 interface QueryHookOptions extends SubscriptionOptions {
   skip?: boolean;
+  refetchOnMount?: boolean;
 }
 
 declare module './apiTypes' {
@@ -117,7 +118,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   }
 
   function buildQueryHook(name: string): QueryHook<any> {
-    return (arg: any, { skip = false, pollingInterval = 0 } = {}) => {
+    return (arg: any, { refetchOnMount = false, skip = false, pollingInterval = 0 } = {}) => {
       const { select, initiate } = api.endpoints[name] as ApiEndpointQuery<
         QueryDefinition<any, any, any, any, any>,
         Definitions
@@ -143,10 +144,12 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           lastPromise.updateSubscriptionOptions({ pollingInterval });
         } else {
           if (lastPromise) lastPromise.unsubscribe();
-          const promise = dispatch(initiate(stableArg, { subscriptionOptions: { pollingInterval } }));
+          const promise = dispatch(
+            initiate(stableArg, { subscriptionOptions: { pollingInterval }, forceRefetch: refetchOnMount })
+          );
           promiseRef.current = promise;
         }
-      }, [stableArg, dispatch, skip, pollingInterval, initiate]);
+      }, [stableArg, dispatch, skip, pollingInterval, refetchOnMount, initiate]);
 
       useEffect(() => {
         return () => void promiseRef.current?.unsubscribe();

--- a/src/buildThunks.ts
+++ b/src/buildThunks.ts
@@ -136,14 +136,14 @@ export function buildThunks<
   endpointDefinitions,
   serializeQueryArgs,
   api,
-  refetchOnMount: baseRefetchOnMount = false,
+  refetchOnMountOrArgChange: baserefetchOnMountOrArgChange = false,
 }: {
   baseQuery: BaseQuery;
   reducerPath: ReducerPath;
   endpointDefinitions: Definitions;
   serializeQueryArgs: InternalSerializeQueryArgs<BaseQueryArg<BaseQuery>>;
   api: Api<BaseQuery, Definitions, ReducerPath, string>;
-  refetchOnMount: boolean | number;
+  refetchOnMountOrArgChange: boolean | number;
 }) {
   type InternalQueryArgs = BaseQueryArg<BaseQuery>;
   type State = InternalRootState<ReducerPath>;
@@ -218,9 +218,9 @@ export function buildThunks<
         const fulfilledVal = requestState?.fulfilledTimeStamp;
         const refetchVal = arg.forceRefetch
           ? arg.forceRefetch
-          : typeof arg.refetchOnMount !== 'undefined'
-          ? arg.refetchOnMount
-          : baseRefetchOnMount;
+          : typeof arg.refetchOnMountOrArgChange !== 'undefined'
+          ? arg.refetchOnMountOrArgChange
+          : baserefetchOnMountOrArgChange;
 
         // Don't retry a request that's currently in-flight
         if (requestState?.status === 'pending') return false;

--- a/src/buildThunks.ts
+++ b/src/buildThunks.ts
@@ -136,12 +136,14 @@ export function buildThunks<
   endpointDefinitions,
   serializeQueryArgs,
   api,
+  refetchOnMount: baseRefetchOnMount = false,
 }: {
   baseQuery: BaseQuery;
   reducerPath: ReducerPath;
   endpointDefinitions: Definitions;
   serializeQueryArgs: InternalSerializeQueryArgs<BaseQueryArg<BaseQuery>>;
   api: Api<BaseQuery, Definitions, ReducerPath, string>;
+  refetchOnMount: boolean | number;
 }) {
   type InternalQueryArgs = BaseQueryArg<BaseQuery>;
   type State = InternalRootState<ReducerPath>;
@@ -211,8 +213,29 @@ export function buildThunks<
     },
     {
       condition(arg, { getState }) {
-        let requestState = getState()[reducerPath]?.queries?.[arg.queryCacheKey];
-        return !(requestState?.status === 'pending' || (requestState?.status === 'fulfilled' && !arg.forceRefetch));
+        const requestState = getState()[reducerPath]?.queries?.[arg.queryCacheKey];
+
+        const fulfilledVal = requestState?.fulfilledTimeStamp;
+        const refetchVal = arg.forceRefetch
+          ? arg.forceRefetch
+          : typeof arg.refetchOnMount !== 'undefined'
+          ? arg.refetchOnMount
+          : baseRefetchOnMount;
+
+        // Don't retry a request that's currently in-flight
+        if (requestState?.status === 'pending') return false;
+
+        // Pull from the cache unless we explicitly force refetch or qualify based on time
+        if (fulfilledVal) {
+          if (refetchVal) {
+            // Return if its true or compare the dates because it must be a number
+            return refetchVal === true || (Number(new Date()) - Number(fulfilledVal)) / 1000 >= refetchVal;
+          }
+          // Value is cached and we didn't specify to refresh, skip it.
+          return false;
+        }
+
+        return true;
       },
       dispatchConditionRejection: true,
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function createApi<
   serializeQueryArgs = defaultSerializeQueryArgs,
   endpoints,
   keepUnusedDataFor = 60,
-  refetchOnMount = false,
+  refetchOnMountOrArgChange = false,
 }: {
   baseQuery: BaseQuery;
   entityTypes?: readonly EntityTypes[];
@@ -45,7 +45,7 @@ export function createApi<
   serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>;
   endpoints(build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>): Definitions;
   keepUnusedDataFor?: number;
-  refetchOnMount?: boolean | number;
+  refetchOnMountOrArgChange?: boolean | number;
 }): Api<BaseQuery, Definitions, ReducerPath, EntityTypes> {
   type State = CombinedState<Definitions, EntityTypes>;
 
@@ -102,7 +102,7 @@ export function createApi<
     endpointDefinitions,
     api,
     serializeQueryArgs,
-    refetchOnMount,
+    refetchOnMountOrArgChange,
   });
   Object.assign(api.util, { patchQueryResult, updateQueryResult });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export function createApi<
   serializeQueryArgs = defaultSerializeQueryArgs,
   endpoints,
   keepUnusedDataFor = 60,
+  refetchOnMount = false,
 }: {
   baseQuery: BaseQuery;
   entityTypes?: readonly EntityTypes[];
@@ -44,6 +45,7 @@ export function createApi<
   serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>;
   endpoints(build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>): Definitions;
   keepUnusedDataFor?: number;
+  refetchOnMount?: boolean | number;
 }): Api<BaseQuery, Definitions, ReducerPath, EntityTypes> {
   type State = CombinedState<Definitions, EntityTypes>;
 
@@ -100,6 +102,7 @@ export function createApi<
     endpointDefinitions,
     api,
     serializeQueryArgs,
+    refetchOnMount,
   });
   Object.assign(api.util, { patchQueryResult, updateQueryResult });
 


### PR DESCRIPTION
- Add `refetchOnMountOrArgChange` to `createApi` as well as into the `useQuery` hook or `initiate` action creators
- Adds tests for these cases, as well as a few more missing things