### PR TITLE
split query hooks, add sub-selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "axios": "^0.21.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
-    "msw": "^0.22.3",
+    "msw": "^0.24.2",
     "node-fetch": "^2.6.1",
     "prettier": "^2.2.0",
     "react": "^16.14.0 || 17.0.0",

--- a/src/buildHooks.ts
+++ b/src/buildHooks.ts
@@ -15,7 +15,7 @@ import { QueryResultSelectorResult, skipSelector } from './buildSelectors';
 import { QueryActionCreatorResult, MutationActionCreatorResult } from './buildActionMaps';
 import { useShallowStableValue } from './utils';
 import { Api, ApiEndpointMutation, ApiEndpointQuery } from './apiTypes';
-import { Id, Override } from './tsHelpers';
+import { Id, NoInfer, Override } from './tsHelpers';
 
 interface QueryHooks<Definition extends QueryDefinition<any, any, any, any, any>> {
   useQuery: UseQuery<Definition>;
@@ -73,7 +73,7 @@ export type UseQueryStateOptions<D extends QueryDefinition<any, any, any, any>, 
   subSelector?: QueryStateSelector<R, D>;
 };
 
-export type UseQueryStateResult<_ extends QueryDefinition<any, any, any, any>, R> = R;
+export type UseQueryStateResult<_ extends QueryDefinition<any, any, any, any>, R> = NoInfer<R>;
 
 type UseQueryStateBaseResult<D extends QueryDefinition<any, any, any, any>> = QuerySubState<D> & {
   /**

--- a/src/buildSelectors.ts
+++ b/src/buildSelectors.ts
@@ -43,7 +43,11 @@ declare module './apiTypes' {
 
 type QueryResultSelector<Definition extends QueryDefinition<any, any, any, any>, RootState> = (
   queryArg: QueryArgFrom<Definition> | typeof skipSelector
-) => (state: RootState) => QuerySubState<Definition> & RequestStatusFlags;
+) => (state: RootState) => QueryResultSelectorResult<Definition>;
+
+export type QueryResultSelectorResult<
+  Definition extends QueryDefinition<any, any, any, any>
+> = QuerySubState<Definition> & RequestStatusFlags;
 
 type MutationResultSelector<Definition extends MutationDefinition<any, any, any, any>, RootState> = (
   requestId: string | typeof skipSelector

--- a/src/buildSlice.ts
+++ b/src/buildSlice.ts
@@ -18,7 +18,7 @@ import type { MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks
 import { AssertEntityTypes, calculateProvidedBy, EndpointDefinitions } from './endpointDefinitions';
 import { applyPatches, Patch } from 'immer';
 import { onFocus, onFocusLost, onOffline, onOnline } from './setupListeners';
-import { isDocumentVisible, isOnline } from './utils';
+import { isDocumentVisible, isOnline, copyWithStructuralSharing } from './utils';
 
 function updateQuerySubstateIfExists(
   state: QueryState<any>,
@@ -96,7 +96,7 @@ export function buildSlice({
           updateQuerySubstateIfExists(draft, meta.arg.queryCacheKey, (substate) => {
             if (substate.requestId !== meta.requestId) return;
             substate.status = QueryStatus.fulfilled;
-            substate.data = payload.result;
+            substate.data = copyWithStructuralSharing(substate.data, payload.result);
             substate.error = undefined;
             substate.fulfilledTimeStamp = payload.fulfilledTimeStamp;
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export function createApi<
     serializeQueryArgs,
   });
 
-  const { buildQueryHook, buildMutationHook, usePrefetch } = buildHooks({ api });
+  const { buildQueryHooks, buildMutationHook, usePrefetch } = buildHooks({ api });
 
   api.usePrefetch = usePrefetch;
 
@@ -175,11 +175,13 @@ export function createApi<
 
       assertCast<Api<InternalQueryArgs, Record<string, any>, ReducerPath, EntityTypes>>(api);
       if (isQueryDefinition(definition)) {
-        const useQuery = buildQueryHook(endpoint);
+        const { useQuery, useQueryState, useQuerySubscription } = buildQueryHooks(endpoint);
         api.endpoints[endpoint] = {
           select: buildQuerySelector(endpoint, definition),
           initiate: buildQueryAction(endpoint, definition),
           useQuery,
+          useQueryState,
+          useQuerySubscription,
           ...buildMatchThunkActions(queryThunk, endpoint),
         };
         (api as any)[`use${capitalize(endpoint)}Query`] = useQuery;

--- a/src/ts41Types.ts
+++ b/src/ts41Types.ts
@@ -1,4 +1,4 @@
-import { MutationHook, QueryHook } from './buildHooks';
+import { MutationHook, UseQuery } from './buildHooks';
 import { EndpointDefinition, EndpointDefinitions, MutationDefinition, QueryDefinition } from './endpointDefinitions';
 
 export type TS41Hooks<Definitions extends EndpointDefinitions> = {
@@ -8,7 +8,7 @@ export type TS41Hooks<Definitions extends EndpointDefinitions> = {
     any,
     any
   >
-    ? QueryHook<Definitions[K]>
+    ? UseQuery<Definitions[K]>
     : Definitions[K] extends MutationDefinition<any, any, any, any>
     ? MutationHook<Definitions[K]>
     : never;

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -13,3 +13,5 @@ export type NonOptionalKeys<T> = { [K in keyof T]-?: undefined extends T[K] ? ne
 export type HasRequiredProps<T, True, False> = NonOptionalKeys<T> extends never ? False : True;
 
 export type OptionalIfAllPropsOptional<T> = HasRequiredProps<T, T, T | never>;
+
+export type NoInfer<T> = [T][T extends any ? 0 : never];

--- a/src/utils/copyWithStructuralSharing.ts
+++ b/src/utils/copyWithStructuralSharing.ts
@@ -1,0 +1,24 @@
+import { isPlainObject as _iPO } from '@reduxjs/toolkit';
+
+// remove type guard
+const isPlainObject: (_: any) => boolean = _iPO;
+
+export function copyWithStructuralSharing<T>(oldObj: any, newObj: T): T;
+export function copyWithStructuralSharing(oldObj: any, newObj: any): any {
+  if (
+    oldObj === newObj ||
+    !((isPlainObject(oldObj) && isPlainObject(newObj)) || (Array.isArray(oldObj) && Array.isArray(newObj)))
+  ) {
+    return newObj;
+  }
+  const newKeys = Object.keys(newObj);
+  const oldKeys = Object.keys(oldObj);
+
+  let isSameObject = newKeys.length === oldKeys.length;
+  const mergeObj: any = Array.isArray(newObj) ? [] : {};
+  for (const key of newKeys) {
+    mergeObj[key] = copyWithStructuralSharing(oldObj[key], newObj[key]);
+    if (isSameObject) isSameObject = oldObj[key] === mergeObj[key];
+  }
+  return isSameObject ? oldObj : mergeObj;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './capitalize';
 export * from './isDev';
 export * from './isOnline';
 export * from './isDocumentVisible';
+export * from './copyWithStructuralSharing';

--- a/test/copyWithStructuralSharing.test.ts
+++ b/test/copyWithStructuralSharing.test.ts
@@ -1,0 +1,68 @@
+import { copyWithStructuralSharing } from '@internal/utils';
+
+test('equal object from JSON Object', () => {
+  const json = JSON.stringify({ a: { b: { c: { d: 1, e: '2', f: true }, g: false }, h: null }, i: null });
+  const objA = JSON.parse(json);
+  const objB = JSON.parse(json);
+  expect(objA).toStrictEqual(objB);
+  expect(objA).not.toBe(objB);
+  const newCopy = copyWithStructuralSharing(objA, objB);
+  expect(newCopy).toBe(objA);
+  expect(newCopy).not.toBe(objB);
+  expect(newCopy).toStrictEqual(objB);
+});
+
+test('equal object from JSON Object', () => {
+  const json = JSON.stringify({ a: { b: { c: { d: 1, e: '2', f: true }, g: false }, h: null }, i: null });
+  const objA = JSON.parse(json);
+  const objB = JSON.parse(json);
+  objB.a.h = 4;
+  expect(objA).not.toStrictEqual(objB);
+  expect(objA).not.toBe(objB);
+  expect(objA.a.b).toStrictEqual(objB.a.b);
+  expect(objA.a.b).not.toBe(objB.a.b);
+
+  const newCopy = copyWithStructuralSharing(objA, objB);
+  expect(newCopy).not.toBe(objA);
+  expect(newCopy).not.toStrictEqual(objA);
+  expect(newCopy).toStrictEqual(objB);
+
+  expect(newCopy.a.b).toBe(objA.a.b);
+  expect(newCopy.a.b).not.toBe(objB.a.b);
+  expect(newCopy.a.b).toStrictEqual(objB.a.b);
+});
+
+test('equal object from JSON Array', () => {
+  const json = JSON.stringify([1, 'a', { 2: 'b' }, { 3: { 4: 'c' }, d: null }, null, 5]);
+  const objA = JSON.parse(json);
+  const objB = JSON.parse(json);
+
+  expect(objA).toStrictEqual(objB);
+  expect(objA).not.toBe(objB);
+  const newCopy = copyWithStructuralSharing(objA, objB);
+  expect(newCopy).toBe(objA);
+  expect(newCopy).not.toBe(objB);
+  expect(newCopy).toStrictEqual(objB);
+});
+
+test('equal object from JSON Array', () => {
+  const json = JSON.stringify([1, 'a', { 2: 'b' }, { 3: { 4: 'c' }, d: null }, null, 5]);
+  const objA = JSON.parse(json);
+  const objB = JSON.parse(json);
+  objB[2][2] = 'x';
+
+  expect(objA).not.toStrictEqual(objB);
+  expect(objA).not.toBe(objB);
+  const newCopy = copyWithStructuralSharing(objA, objB);
+  expect(newCopy).not.toBe(objA);
+  expect(newCopy).not.toBe(objB);
+  expect(newCopy).toStrictEqual(objB);
+
+  expect(newCopy[3]).toBe(objA[3]);
+  expect(newCopy[3]).not.toBe(objB[3]);
+  expect(newCopy[3]).toStrictEqual(objB[3]);
+
+  expect(newCopy[2]).not.toBe(objA[2]);
+  expect(newCopy[2]).not.toBe(objB[2]);
+  expect(newCopy[2]).toStrictEqual(objB[2]);
+});

--- a/test/unionTypes.test.ts
+++ b/test/unionTypes.test.ts
@@ -53,7 +53,7 @@ describe.skip('TS only tests', () => {
       expectType<never>(result);
     }
   });
-  test('queryHookResult union', () => {
+  test('useQuery union', () => {
     const result = api.useTestQuery();
 
     if (result.isUninitialized) {
@@ -108,5 +108,27 @@ describe.skip('TS only tests', () => {
     if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
       expectType<never>(result);
     }
+  });
+
+  test('queryHookResult (without selector) union', () => {
+    const useQueryStateResult = api.endpoints.test.useQueryState();
+    const useQueryResult = api.endpoints.test.useQuery();
+    const useQueryStateWithSubSelector = api.endpoints.test.useQueryState(undefined, {
+      subSelector: () => true,
+    });
+
+    const { refetch: _omit, ...useQueryResultWithoutMethods } = useQueryResult;
+    expectExactType(useQueryStateResult)(useQueryResultWithoutMethods);
+    // @ts-expect-error
+    expectExactType(useQueryStateWithSubSelector)(useQueryResultWithoutMethods);
+  });
+
+  test('queryHookResult (with subSelector)', () => {
+    const result = api.endpoints.test.useQueryState(undefined, {
+      subSelector({ data, isLoading }) {
+        return { data: data ?? 1, isLoading };
+      },
+    });
+    expectExactType({ data: '' as string | number, isLoading: true as boolean })(result);
   });
 });

--- a/test/unionTypes.test.ts
+++ b/test/unionTypes.test.ts
@@ -123,12 +123,21 @@ describe.skip('TS only tests', () => {
     expectExactType(useQueryStateWithSubSelector)(useQueryResultWithoutMethods);
   });
 
-  test('queryHookResult (with subSelector)', () => {
+  test('useQueryState (with subSelector)', () => {
     const result = api.endpoints.test.useQueryState(undefined, {
       subSelector({ data, isLoading }) {
         return { data: data ?? 1, isLoading };
       },
     });
     expectExactType({ data: '' as string | number, isLoading: true as boolean })(result);
+  });
+
+  test('useQuery (with subSelector)', () => {
+    const result = api.endpoints.test.useQuery(undefined, {
+      subSelector({ data, isLoading }) {
+        return { data: data ?? 1, isLoading };
+      },
+    });
+    expectExactType({ data: '' as string | number, isLoading: true as boolean, refetch: () => {} })(result);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,10 +6199,10 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-msw@^0.22.3:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/msw/-/msw-0.22.3.tgz#56a49d6ef8a1452b4c39f55928c152d29cdf5eec"
-  integrity sha512-rrxRf/6XEjvtL4rkwgxh7CG8Wn+sebHKt+GW4UBLhLRoMeeAG0zwGZGVYvDDbx6od/cKFEqCbEAb2JCk1dah8Q==
+msw@^0.24.2:
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.24.2.tgz#6c630400e0be7f5ea5ad6334af5806bac4d82977"
+  integrity sha512-lQubV+wer9Wa08sTxzEEzyxew+f8vQiOtXIKvy+hvrK+pD/G55NSqzzs6wkY3mHcsCVcPuac8Zssg2uvkvyREQ==
   dependencies:
     "@open-draft/until" "^1.0.3"
     "@types/cookie" "^0.4.0"


### PR DESCRIPTION
This splits `useQuery` up into `useQueryState` and `useQuerySubscription`.

`useQueryState` returns the enhanced querySubState like before, but allows for an option `subSelector` to select only a partial result.

`useQuerySubscription` starts a query, subscribes to it and only returns `{refetch}`.

`useQuery` calls both of them. Right now, `useQuery` does not accept a subselector yet, but I might change that, depending on the resulting complexity.

closes #79  #84 #96 