### PR TITLE
deprecate UseQueryStateDefaultResult.status

### DIFF
--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -99,7 +99,14 @@ type UseQueryStateDefaultResult<D extends QueryDefinition<any, any, any, any>> =
         >)
       | ({ isError: true } & Required<Pick<UseQueryStateBaseResult<D>, 'error'>>)
     >
->;
+> & {
+  /**
+   * @deprecated will be removed in the next version
+   * please use the `isLoading`, `isFetching`, `isSuccess`, `isError`
+   * and `isUninitialized` flags instead
+   */
+  status: QueryStatus;
+};
 
 export type MutationHook<D extends MutationDefinition<any, any, any, any>> = () => [
   (


### PR DESCRIPTION
as it might be misleading in some circumstances