### PR TITLE
Make prepareHeaders support async functions

### DIFF
--- a/src/fetchBaseQuery.ts
+++ b/src/fetchBaseQuery.ts
@@ -1,7 +1,7 @@
 import { joinUrls } from './utils';
 import { isPlainObject } from '@reduxjs/toolkit';
 import { BaseQueryFn } from './baseQueryTypes';
-import { Override } from './tsHelpers';
+import { MaybePromise, Override } from './tsHelpers';
 
 export type ResponseHandler = 'json' | 'text' | ((response: Response) => Promise<any>);
 
@@ -79,7 +79,7 @@ export function fetchBaseQuery({
   ...baseFetchOptions
 }: {
   baseUrl?: string;
-  prepareHeaders?: (headers: Headers, api: { getState: () => unknown }) => Headers;
+  prepareHeaders?: (headers: Headers, api: { getState: () => unknown }) => MaybePromise<Headers>;
   fetchFn?: (input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>;
 } & RequestInit = {}): BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}> {
   return async (arg, { signal, getState }) => {
@@ -101,7 +101,7 @@ export function fetchBaseQuery({
       ...rest,
     };
 
-    config.headers = prepareHeaders(new Headers(cleanUndefinedHeaders(headers)), { getState });
+    config.headers = await prepareHeaders(new Headers(cleanUndefinedHeaders(headers)), { getState });
 
     if (!config.headers.has('content-type')) {
       config.headers.set('content-type', 'application/json');

--- a/test/fetchBaseQuery.test.tsx
+++ b/test/fetchBaseQuery.test.tsx
@@ -322,6 +322,36 @@ describe('fetchBaseQuery', () => {
       expect(request.headers['delete2']).toBeUndefined();
     });
 
+    test('prepareHeaders is able to be an async function', async () => {
+      let request: any;
+
+      const token = 'accessToken';
+      const getAccessTokenAsync = async () => token;
+
+      const _baseQuery = fetchBaseQuery({
+        baseUrl,
+        prepareHeaders: async (headers) => {
+          headers.set('authorization', `Bearer ${await getAccessTokenAsync()}`);
+          return headers;
+        },
+      });
+
+      const doRequest = async () =>
+        _baseQuery(
+          { url: '/echo' },
+          {
+            signal: undefined,
+            dispatch: storeRef.store.dispatch,
+            getState: storeRef.store.getState,
+          },
+          {}
+        );
+
+      ({ data: request } = await doRequest());
+
+      expect(request.headers['authorization']).toBe(`Bearer ${token}`);
+    });
+
     test('prepareHeaders is able to select from a state', async () => {
       let request: any;
 


### PR DESCRIPTION
I'm trying to use the `prepareHeaders` function to add an `accessToken` to my API requests. Unfortunately the function I'd have to use to get the `accessToken` in our setup is asynchronous.

So my proposal would be: Make the `prepareHeaders` function support async functions.
Since this is being called in an asynchronous function anyways there's not a lot to change and it'd save us a lot of overhead by not having to put the `accessToken` into state first and then get it from there.

Hopefully it'll also help some other users :)