### PR TITLE
Smarter handling optional parameters

### DIFF
--- a/src/fetchBaseQuery.ts
+++ b/src/fetchBaseQuery.ts
@@ -42,7 +42,7 @@ export interface FetchBaseQueryError {
   data: unknown;
 }
 
-function cleanUndefinedHeaders(headers: any) {
+function excludeUndefined(headers: any) {
   if (!isPlainObject(headers)) {
     return headers;
   }
@@ -101,7 +101,7 @@ export function fetchBaseQuery({
       ...rest,
     };
 
-    config.headers = await prepareHeaders(new Headers(cleanUndefinedHeaders(headers)), { getState });
+    config.headers = await prepareHeaders(new Headers(excludeUndefined(headers)), { getState });
 
     if (!config.headers.has('content-type')) {
       config.headers.set('content-type', 'application/json');
@@ -113,7 +113,7 @@ export function fetchBaseQuery({
 
     if (params) {
       const divider = ~url.indexOf('?') ? '&' : '?';
-      const query = new URLSearchParams(params);
+      const query = new URLSearchParams(excludeUndefined(params));
       url += divider + query;
     }
 

--- a/src/fetchBaseQuery.ts
+++ b/src/fetchBaseQuery.ts
@@ -42,11 +42,11 @@ export interface FetchBaseQueryError {
   data: unknown;
 }
 
-function excludeUndefined(headers: any) {
-  if (!isPlainObject(headers)) {
-    return headers;
+function stripUndefined(obj: any) {
+  if (!isPlainObject(obj)) {
+    return obj;
   }
-  const copy: Record<string, any> = { ...headers };
+  const copy: Record<string, any> = { ...obj };
   for (const [k, v] of Object.entries(copy)) {
     if (typeof v === 'undefined') delete copy[k];
   }
@@ -101,7 +101,7 @@ export function fetchBaseQuery({
       ...rest,
     };
 
-    config.headers = await prepareHeaders(new Headers(excludeUndefined(headers)), { getState });
+    config.headers = await prepareHeaders(new Headers(stripUndefined(headers)), { getState });
 
     if (!config.headers.has('content-type')) {
       config.headers.set('content-type', 'application/json');
@@ -113,7 +113,7 @@ export function fetchBaseQuery({
 
     if (params) {
       const divider = ~url.indexOf('?') ? '&' : '?';
-      const query = new URLSearchParams(excludeUndefined(params));
+      const query = new URLSearchParams(stripUndefined(params));
       url += divider + query;
     }
 

--- a/test/fetchBaseQuery.test.tsx
+++ b/test/fetchBaseQuery.test.tsx
@@ -221,6 +221,23 @@ describe('fetchBaseQuery', () => {
 
       expect(request.url).toEqual(`${baseUrl}/echo?apple=fruit`);
     });
+
+    it('should strip undefined values from the end params', async () => {
+      const params = { apple: 'fruit', banana: undefined, randy: null };
+
+      let request: any;
+      ({ data: request } = await baseQuery(
+        { url: '/echo', params },
+        {
+          signal: undefined,
+          dispatch: storeRef.store.dispatch,
+          getState: storeRef.store.getState,
+        },
+        {}
+      ));
+
+      expect(request.url).toEqual(`${baseUrl}/echo?apple=fruit&randy=null`);
+    });
   });
 
   describe('validateStatus', () => {


### PR DESCRIPTION
```
console.log(new URLSearchParams({ a: 'helloworld', b: undefined }).toString())
"a=helloworld&b=undefined"
```

This b=undefined should be unintentional, so undefined should be removed.
