### PR TITLE
Redux Toolkit: responseHandler should always be serializable

### DIFF
--- a/src/fetchBaseQuery.ts
+++ b/src/fetchBaseQuery.ts
@@ -3,7 +3,7 @@ import { isPlainObject } from '@reduxjs/toolkit';
 import { BaseQueryFn } from './baseQueryTypes';
 import { MaybePromise, Override } from './tsHelpers';
 
-export type ResponseHandler = 'json' | 'text' | ((response: Response) => Promise<any>);
+export type ResponseHandler = 'json' | 'text' | 'raw';
 
 type CustomRequestInit = Override<
   RequestInit,
@@ -23,8 +23,8 @@ const defaultValidateStatus = (response: Response) => response.status >= 200 && 
 const isJsonContentType = (headers: Headers) => headers.get('content-type')?.trim()?.startsWith('application/json');
 
 const handleResponse = async (response: Response, responseHandler: ResponseHandler) => {
-  if (typeof responseHandler === 'function') {
-    return responseHandler(response);
+  if (responseHandler === 'raw') {
+    return response;
   }
 
   if (responseHandler === 'text') {


### PR DESCRIPTION
Addresses points brought up in https://github.com/rtk-incubator/rtk-query/issues/154

We have a use case where we need to consume the headers of the response. It looks like that we could handle this case through `responseHandler` by returning the raw Response : `(response) => response`. However, it seems that Redux Toolkit complains when `responseHandler` [is a function](https://rtk-query-docs.netlify.app/api/fetchbasequery/#parsing-a-response) (because it is [not serializable](https://redux.js.org/style-guide/style-guide#do-not-put-non-serializable-values-in-state-or-actions)). Thus, it appears that a suitable approach would be to simply add `'raw'` as a potential `responseHandler` type, then to handle the raw Response with `transformResponse` (see corresponding tests).