### PR TITLE
remove internalQueryArgs

### DIFF
--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -29,7 +29,7 @@ export type Module<Name extends ModuleName> = {
     options: Required<CreateApiOptions<BaseQuery, Definitions, ReducerPath, EntityTypes>>,
     context: ApiContext<Definitions>
   ): {
-    injectEndpoint(endpoint: string, definition: EndpointDefinition<any, any, any, any>): void;
+    injectEndpoint(endpointName: string, definition: EndpointDefinition<any, any, any, any>): void;
   };
 };
 

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -82,13 +82,12 @@ export type MutationKeys<Definitions extends EndpointDefinitions> = {
 
 type BaseQuerySubState<D extends BaseEndpointDefinition<any, any, any>> = {
   originalArgs: QueryArgFrom<D>;
-  internalQueryArgs: unknown;
   requestId: string;
   data?: ResultTypeFrom<D>;
   error?:
     | SerializedError
     | (D extends QueryDefinition<any, infer BaseQuery, any, any> ? BaseQueryError<BaseQuery> : never);
-  endpoint: string;
+  endpointName: string;
   startedTimeStamp: number;
   fulfilledTimeStamp?: number;
 };
@@ -106,11 +105,10 @@ export type QuerySubState<D extends BaseEndpointDefinition<any, any, any>> = Id<
   | {
       status: QueryStatus.uninitialized;
       originalArgs?: undefined;
-      internalQueryArgs?: undefined;
       data?: undefined;
       error?: undefined;
       requestId?: undefined;
-      endpoint?: string;
+      endpointName?: string;
       startedTimeStamp?: undefined;
       fulfilledTimeStamp?: undefined;
     }
@@ -118,12 +116,11 @@ export type QuerySubState<D extends BaseEndpointDefinition<any, any, any>> = Id<
 
 type BaseMutationSubState<D extends BaseEndpointDefinition<any, any, any>> = {
   originalArgs?: QueryArgFrom<D>;
-  internalQueryArgs: unknown;
   data?: ResultTypeFrom<D>;
   error?:
     | SerializedError
     | (D extends MutationDefinition<any, infer BaseQuery, any, any> ? BaseQueryError<BaseQuery> : never);
-  endpoint: string;
+  endpointName: string;
   startedTimeStamp: number;
   fulfilledTimeStamp?: number;
 };
@@ -141,10 +138,9 @@ export type MutationSubState<D extends BaseEndpointDefinition<any, any, any>> =
   | {
       status: QueryStatus.uninitialized;
       originalArgs?: undefined;
-      internalQueryArgs?: undefined;
       data?: undefined;
       error?: undefined;
-      endpoint?: string;
+      endpointName?: string;
       startedTimeStamp?: undefined;
       fulfilledTimeStamp?: undefined;
     };

--- a/src/core/buildInitiate.ts
+++ b/src/core/buildInitiate.ts
@@ -91,7 +91,7 @@ export function buildInitiate<InternalQueryArgs>({
       arg,
       { subscribe = true, forceRefetch, subscriptionOptions } = {}
     ) => (dispatch, getState) => {
-      const queryCacheKey = serializeQueryArgs({ queryArgs: arg, endpointDefinition, endpointName: endpointName });
+      const queryCacheKey = serializeQueryArgs({ queryArgs: arg, endpointDefinition, endpointName });
       const thunk = queryThunk({
         subscribe,
         forceRefetch,

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -44,7 +44,7 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     if (mutationThunk.fulfilled.match(action)) {
       invalidateEntities(
         calculateProvidedBy(
-          endpointDefinitions[action.meta.arg.endpoint].invalidates,
+          endpointDefinitions[action.meta.arg.endpointName].invalidates,
           action.payload.result,
           action.meta.arg.originalArgs,
           assertEntityType
@@ -85,9 +85,8 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     override: Partial<QueryThunkArg<any>> = {}
   ) {
     return queryThunk({
-      endpoint: querySubState.endpoint,
+      endpointName: querySubState.endpointName,
       originalArgs: querySubState.originalArgs,
-      internalQueryArgs: querySubState.internalQueryArgs,
       subscribe: false,
       forceRefetch: true,
       startedTimeStamp: Date.now(),

--- a/src/core/buildSelectors.ts
+++ b/src/core/buildSelectors.ts
@@ -84,18 +84,17 @@ export function buildSelectors<InternalQueryArgs, Definitions extends EndpointDe
   }
 
   function buildQuerySelector(
-    endpoint: string,
-    definition: QueryDefinition<any, any, any, any>
+    endpointName: string,
+    endpointDefinition: QueryDefinition<any, any, any, any>
   ): QueryResultSelector<any, RootState> {
-    return (arg?) => {
+    return (queryArgs) => {
       const selectQuerySubState = createSelector(
         selectInternalState,
         (internalState) =>
-          (arg === skipSelector
+          (queryArgs === skipSelector
             ? undefined
-            : internalState.queries[
-                serializeQueryArgs({ queryArgs: arg, internalQueryArgs: definition.query(arg), endpoint })
-              ]) ?? defaultQuerySubState
+            : internalState.queries[serializeQueryArgs({ queryArgs, endpointDefinition, endpointName })]) ??
+          defaultQuerySubState
       );
       return createSelector(selectQuerySubState, withRequestFlags);
     };

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -81,14 +81,13 @@ export function buildSlice({
             // only initialize substate if we want to subscribe to it
             draft[arg.queryCacheKey] ??= {
               status: QueryStatus.uninitialized,
-              endpoint: arg.endpoint,
+              endpointName: arg.endpointName,
             };
           }
 
           updateQuerySubstateIfExists(draft, arg.queryCacheKey, (substate) => {
             substate.status = QueryStatus.pending;
             substate.requestId = requestId;
-            substate.internalQueryArgs = arg.internalQueryArgs;
             substate.originalArgs = arg.originalArgs;
             substate.startedTimeStamp = arg.startedTimeStamp;
           });
@@ -133,9 +132,8 @@ export function buildSlice({
 
           draft[requestId] = {
             status: QueryStatus.pending,
-            internalQueryArgs: arg.internalQueryArgs,
             originalArgs: arg.originalArgs,
-            endpoint: arg.endpoint,
+            endpointName: arg.endpointName,
             startedTimeStamp: arg.startedTimeStamp,
           };
         })
@@ -166,9 +164,9 @@ export function buildSlice({
     extraReducers(builder) {
       builder
         .addCase(queryThunk.fulfilled, (draft, { payload, meta: { arg } }) => {
-          const { endpoint, queryCacheKey } = arg;
+          const { endpointName, queryCacheKey } = arg;
           const providedEntities = calculateProvidedBy(
-            definitions[endpoint].provides,
+            definitions[endpointName].provides,
             payload.result,
             arg.originalArgs,
             assertEntityType
@@ -203,7 +201,7 @@ export function buildSlice({
         {
           payload: { queryCacheKey, requestId, options },
         }: PayloadAction<
-          { endpoint: string; requestId: string; options: Subscribers[number] } & QuerySubstateIdentifier
+          { endpointName: string; requestId: string; options: Subscribers[number] } & QuerySubstateIdentifier
         >
       ) {
         if (draft?.[queryCacheKey]?.[requestId]) {

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -73,17 +73,15 @@ export interface Matchers<
   matchRejected: Matcher<RejectedAction<Thunk, Definition>>;
 }
 
-export interface QueryThunkArg<InternalQueryArgs> extends QuerySubstateIdentifier, StartQueryActionCreatorOptions {
+export interface QueryThunkArg<_InternalQueryArgs> extends QuerySubstateIdentifier, StartQueryActionCreatorOptions {
   originalArgs: unknown;
-  endpoint: string;
-  internalQueryArgs: InternalQueryArgs;
+  endpointName: string;
   startedTimeStamp: number;
 }
 
-export interface MutationThunkArg<InternalQueryArgs> {
+export interface MutationThunkArg<_InternalQueryArgs> {
   originalArgs: unknown;
-  endpoint: string;
-  internalQueryArgs: InternalQueryArgs;
+  endpointName: string;
   track?: boolean;
   startedTimeStamp: number;
 }
@@ -144,13 +142,13 @@ export function buildThunks<
   const patchQueryResult: PatchQueryResultThunk<EndpointDefinitions, State> = (endpointName, args, patches) => (
     dispatch
   ) => {
-    const endpoint = endpointDefinitions[endpointName];
+    const endpointDefinition = endpointDefinitions[endpointName];
     dispatch(
       api.internalActions.queryResultPatched({
         queryCacheKey: serializeQueryArgs({
           queryArgs: args,
-          internalQueryArgs: endpoint.query(args),
-          endpoint: endpointName,
+          endpointDefinition,
+          endpointName,
         }),
         patches,
       })
@@ -192,7 +190,7 @@ export function buildThunks<
   >(
     `${reducerPath}/executeQuery`,
     async (arg, { signal, rejectWithValue, ...api }) => {
-      const endpoint = endpointDefinitions[arg.endpoint] as QueryDefinition<any, any, any, any>;
+      const endpointDefinition = endpointDefinitions[arg.endpointName] as QueryDefinition<any, any, any, any>;
 
       const context: Record<string, any> = {};
       const queryApi: QueryApi<ReducerPath, any> = {
@@ -200,23 +198,23 @@ export function buildThunks<
         context,
       };
 
-      if (endpoint.onStart) endpoint.onStart(arg.originalArgs, queryApi);
+      if (endpointDefinition.onStart) endpointDefinition.onStart(arg.originalArgs, queryApi);
 
       try {
         const result = await baseQuery(
-          arg.internalQueryArgs,
+          endpointDefinition.query(arg.originalArgs),
           { signal, dispatch: api.dispatch, getState: api.getState },
-          endpoint.extraOptions as any
+          endpointDefinition.extraOptions as any
         );
         if (result.error) throw new HandledError(result.error);
-        if (endpoint.onSuccess) endpoint.onSuccess(arg.originalArgs, queryApi, result.data);
+        if (endpointDefinition.onSuccess) endpointDefinition.onSuccess(arg.originalArgs, queryApi, result.data);
         return {
           fulfilledTimeStamp: Date.now(),
-          result: await (endpoint.transformResponse ?? defaultTransformResponse)(result.data),
+          result: await (endpointDefinition.transformResponse ?? defaultTransformResponse)(result.data),
         };
       } catch (error) {
-        if (endpoint.onError)
-          endpoint.onError(arg.originalArgs, queryApi, error instanceof HandledError ? error.value : error);
+        if (endpointDefinition.onError)
+          endpointDefinition.onError(arg.originalArgs, queryApi, error instanceof HandledError ? error.value : error);
         if (error instanceof HandledError) {
           return rejectWithValue(error.value);
         }
@@ -256,7 +254,7 @@ export function buildThunks<
     MutationThunkArg<InternalQueryArgs>,
     { state: RootState<any, string, ReducerPath> }
   >(`${reducerPath}/executeMutation`, async (arg, { signal, rejectWithValue, ...api }) => {
-    const endpoint = endpointDefinitions[arg.endpoint] as MutationDefinition<any, any, any, any>;
+    const endpointDefinition = endpointDefinitions[arg.endpointName] as MutationDefinition<any, any, any, any>;
 
     const context: Record<string, any> = {};
     const mutationApi: MutationApi<ReducerPath, any> = {
@@ -264,22 +262,22 @@ export function buildThunks<
       context,
     };
 
-    if (endpoint.onStart) endpoint.onStart(arg.originalArgs, mutationApi);
+    if (endpointDefinition.onStart) endpointDefinition.onStart(arg.originalArgs, mutationApi);
     try {
       const result = await baseQuery(
-        arg.internalQueryArgs,
+        endpointDefinition.query(arg.originalArgs),
         { signal, dispatch: api.dispatch, getState: api.getState },
-        endpoint.extraOptions as any
+        endpointDefinition.extraOptions as any
       );
       if (result.error) throw new HandledError(result.error);
-      if (endpoint.onSuccess) endpoint.onSuccess(arg.originalArgs, mutationApi, result.data);
+      if (endpointDefinition.onSuccess) endpointDefinition.onSuccess(arg.originalArgs, mutationApi, result.data);
       return {
         fulfilledTimeStamp: Date.now(),
-        result: await (endpoint.transformResponse ?? defaultTransformResponse)(result.data),
+        result: await (endpointDefinition.transformResponse ?? defaultTransformResponse)(result.data),
       };
     } catch (error) {
-      if (endpoint.onError)
-        endpoint.onError(arg.originalArgs, mutationApi, error instanceof HandledError ? error.value : error);
+      if (endpointDefinition.onError)
+        endpointDefinition.onError(arg.originalArgs, mutationApi, error instanceof HandledError ? error.value : error);
       if (error instanceof HandledError) {
         return rejectWithValue(error.value);
       }
@@ -320,17 +318,17 @@ export function buildThunks<
     }
   };
 
-  function matchesEndpoint(endpoint: string) {
-    return (action: any): action is AnyAction => action?.meta?.arg?.endpoint === endpoint;
+  function matchesEndpoint(endpointName: string) {
+    return (action: any): action is AnyAction => action?.meta?.arg?.endpointName === endpointName;
   }
 
   function buildMatchThunkActions<
     Thunk extends AsyncThunk<any, QueryThunkArg<any>, any> | AsyncThunk<any, MutationThunkArg<any>, any>
-  >(thunk: Thunk, endpoint: string) {
+  >(thunk: Thunk, endpointName: string) {
     return {
-      matchPending: isAllOf(isPending(thunk), matchesEndpoint(endpoint)),
-      matchFulfilled: isAllOf(isFulfilled(thunk), matchesEndpoint(endpoint)),
-      matchRejected: isAllOf(isRejected(thunk), matchesEndpoint(endpoint)),
+      matchPending: isAllOf(isPending(thunk), matchesEndpoint(endpointName)),
+      matchFulfilled: isAllOf(isFulfilled(thunk), matchesEndpoint(endpointName)),
+      matchRejected: isAllOf(isRejected(thunk), matchesEndpoint(endpointName)),
     } as Matchers<Thunk, any>;
   }
 

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -188,26 +188,26 @@ export const coreModule = (): Module<CoreModule> => ({
 
     return {
       name: coreModuleName,
-      injectEndpoint(endpoint, definition) {
+      injectEndpoint(endpointName, definition) {
         const anyApi = (api as any) as Api<any, Record<string, any>, string, string, CoreModule>;
-        anyApi.endpoints[endpoint] ??= {} as any;
+        anyApi.endpoints[endpointName] ??= {} as any;
         if (isQueryDefinition(definition)) {
           safeAssign(
-            anyApi.endpoints[endpoint],
+            anyApi.endpoints[endpointName],
             {
-              select: buildQuerySelector(endpoint, definition),
-              initiate: buildInitiateQuery(endpoint, definition),
+              select: buildQuerySelector(endpointName, definition),
+              initiate: buildInitiateQuery(endpointName, definition),
             },
-            buildMatchThunkActions(queryThunk, endpoint)
+            buildMatchThunkActions(queryThunk, endpointName)
           );
         } else if (isMutationDefinition(definition)) {
           safeAssign(
-            anyApi.endpoints[endpoint],
+            anyApi.endpoints[endpointName],
             {
               select: buildMutationSelector(),
-              initiate: buildInitiateMutation(endpoint, definition),
+              initiate: buildInitiateMutation(endpointName, definition),
             },
-            buildMatchThunkActions(mutationThunk, endpoint)
+            buildMatchThunkActions(mutationThunk, endpointName)
           );
         }
       },

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -63,11 +63,11 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
           }
         }
         if (endpoints) {
-          for (const [endpoint, partialDefinition] of Object.entries(endpoints)) {
+          for (const [endpointName, partialDefinition] of Object.entries(endpoints)) {
             if (typeof partialDefinition === 'function') {
-              partialDefinition(context.endpointDefinitions[endpoint]);
+              partialDefinition(context.endpointDefinitions[endpointName]);
             }
-            Object.assign(context.endpointDefinitions[endpoint] || {}, partialDefinition);
+            Object.assign(context.endpointDefinitions[endpointName] || {}, partialDefinition);
           }
         }
         return api;
@@ -82,18 +82,18 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
         mutation: (x) => ({ ...x, type: DefinitionType.mutation } as any),
       });
 
-      for (const [endpoint, definition] of Object.entries(evaluatedEndpoints)) {
+      for (const [endpointName, definition] of Object.entries(evaluatedEndpoints)) {
         if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
-          if (!inject.overrideExisting && endpoint in context.endpointDefinitions) {
+          if (!inject.overrideExisting && endpointName in context.endpointDefinitions) {
             console.error(
-              `called \`injectEndpoints\` to override already-existing endpoint ${endpoint} without specifying \`overrideExisting: true\``
+              `called \`injectEndpoints\` to override already-existing endpointName ${endpointName} without specifying \`overrideExisting: true\``
             );
             continue;
           }
         }
-        context.endpointDefinitions[endpoint] = definition;
+        context.endpointDefinitions[endpointName] = definition;
         for (const m of initializedModules) {
-          m.injectEndpoint(endpoint, definition);
+          m.injectEndpoint(endpointName, definition);
         }
       }
 

--- a/src/defaultSerializeQueryArgs.ts
+++ b/src/defaultSerializeQueryArgs.ts
@@ -1,18 +1,19 @@
 import { QueryCacheKey } from './core/apiState';
+import { EndpointDefinition } from './endpointDefinitions';
 
-export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpoint, queryArgs }) => {
+export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpointName, queryArgs }) => {
   // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than  useQuery({ b: 2, a: 1 })
-  return `${endpoint}(${JSON.stringify(queryArgs, Object.keys(queryArgs || {}).sort())})`;
+  return `${endpointName}(${JSON.stringify(queryArgs, Object.keys(queryArgs || {}).sort())})`;
 };
 
-export type SerializeQueryArgs<InternalQueryArgs> = (_: {
+export type SerializeQueryArgs<_InternalQueryArgs> = (_: {
   queryArgs: any;
-  internalQueryArgs: InternalQueryArgs;
-  endpoint: string;
+  endpointDefinition: EndpointDefinition<any, any, any, any>;
+  endpointName: string;
 }) => string;
 
-export type InternalSerializeQueryArgs<InternalQueryArgs> = (_: {
+export type InternalSerializeQueryArgs<_InternalQueryArgs> = (_: {
   queryArgs: any;
-  internalQueryArgs: InternalQueryArgs;
-  endpoint: string;
+  endpointDefinition: EndpointDefinition<any, any, any, any>;
+  endpointName: string;
 }) => QueryCacheKey;

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -65,22 +65,22 @@ export const reactHooksModule = ({
     safeAssign(context, { batch });
 
     return {
-      injectEndpoint(endpoint, definition) {
+      injectEndpoint(endpointName, definition) {
         const anyApi = (api as any) as Api<any, Record<string, any>, string, string, ReactHooksModule>;
         if (isQueryDefinition(definition)) {
-          const { useQuery, useQueryState, useQuerySubscription } = buildQueryHooks(endpoint);
-          safeAssign(anyApi.endpoints[endpoint], {
+          const { useQuery, useQueryState, useQuerySubscription } = buildQueryHooks(endpointName);
+          safeAssign(anyApi.endpoints[endpointName], {
             useQuery,
             useQueryState,
             useQuerySubscription,
           });
-          (api as any)[`use${capitalize(endpoint)}Query`] = useQuery;
+          (api as any)[`use${capitalize(endpointName)}Query`] = useQuery;
         } else if (isMutationDefinition(definition)) {
-          const useMutation = buildMutationHook(endpoint);
-          safeAssign(anyApi.endpoints[endpoint], {
+          const useMutation = buildMutationHook(endpointName);
+          safeAssign(anyApi.endpoints[endpointName], {
             useMutation,
           });
-          (api as any)[`use${capitalize(endpoint)}Mutation`] = useMutation;
+          (api as any)[`use${capitalize(endpointName)}Mutation`] = useMutation;
         }
       },
     };

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -422,10 +422,9 @@ describe('hooks tests', () => {
     userEvent.hover(getByTestId('highPriority'));
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       error: undefined,
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: true,
       isSuccess: false,
@@ -440,9 +439,8 @@ describe('hooks tests', () => {
 
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: false,
       isSuccess: true,
@@ -482,9 +480,8 @@ describe('hooks tests', () => {
 
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: false,
       isSuccess: true,
@@ -499,9 +496,8 @@ describe('hooks tests', () => {
 
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: false,
       isSuccess: true,
@@ -543,9 +539,8 @@ describe('hooks tests', () => {
     userEvent.hover(getByTestId('lowPriority'));
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: true,
       isSuccess: false,
@@ -560,9 +555,8 @@ describe('hooks tests', () => {
 
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
       data: undefined,
-      endpoint: 'getUser',
+      endpointName: 'getUser',
       fulfilledTimeStamp: expect.any(Number),
-      internalQueryArgs: USER_ID,
       isError: false,
       isLoading: false,
       isSuccess: true,
@@ -627,8 +621,7 @@ describe('hooks tests', () => {
     userEvent.hover(getByTestId('lowPriority'));
 
     expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      endpoint: 'getUser',
-      internalQueryArgs: USER_ID,
+      endpointName: 'getUser',
       isError: false,
       isLoading: true,
       isSuccess: false,

--- a/test/buildThunks.test.tsx
+++ b/test/buildThunks.test.tsx
@@ -36,10 +36,7 @@ test('handles a non-async baseQuery without error', async () => {
     data: {
       url: 'user/1',
     },
-    endpoint: 'getUser',
-    internalQueryArgs: {
-      url: 'user/1',
-    },
+    endpointName: 'getUser',
     isError: false,
     isLoading: false,
     isSuccess: true,

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -216,9 +216,8 @@ describe('configuration', () => {
     expect(baseBaseQuery).toHaveBeenCalledTimes(1);
     expect(result.error).toEqual(error);
     expect(result).toEqual({
-      endpoint: 'q1',
+      endpointName: 'q1',
       error,
-      internalQueryArgs: undefined,
       isError: true,
       isLoading: false,
       isSuccess: false,


### PR DESCRIPTION
This would address #154 and #155 in a more broad manner.

Also, I added `endpointDefinition` to `serializeQueryArgs` and renamed `endpoint` to `endpointDefinition` or `endpointName` everywhere to be more consistent.

Hope I didn't change a public API with it :sweat_smile:  (apart from `serializeQueryArgs`)

@msutkowski could you take a look at this? Also, @gfortaine, can you please test if this would solve your problem?