### PR TITLE
Reset promiseRef on useQuery hook

### DIFF
--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -58,6 +58,12 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     }
 
     if (updateSubscriptionOptions.match(action)) {
+      // It shouldn't be possible to update a subscription after it's scheduled to be removed via unsubscribe
+      // but this happens with fast refresh / hot reload. Let's clear the timeout to keep it around.
+      const currentTimeout = currentRemovalTimeouts[action.payload.queryCacheKey];
+      if (currentTimeout) {
+        clearInterval(currentTimeout);
+      }
       updatePollingInterval(action.payload, mwApi);
     }
     if (queryThunk.pending.match(action) || (queryThunk.rejected.match(action) && action.meta.condition)) {

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -58,12 +58,6 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     }
 
     if (updateSubscriptionOptions.match(action)) {
-      // It shouldn't be possible to update a subscription after it's scheduled to be removed via unsubscribe
-      // but this happens with fast refresh / hot reload. Let's clear the timeout to keep it around.
-      const currentTimeout = currentRemovalTimeouts[action.payload.queryCacheKey];
-      if (currentTimeout) {
-        clearInterval(currentTimeout);
-      }
       updatePollingInterval(action.payload, mwApi);
     }
     if (queryThunk.pending.match(action) || (queryThunk.rejected.match(action) && action.meta.condition)) {

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -214,7 +214,11 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       ]);
 
       useEffect(() => {
-        return () => void promiseRef.current?.unsubscribe();
+        return () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          promiseRef.current?.unsubscribe();
+          promiseRef.current = undefined;
+        };
       }, []);
 
       return useMemo(

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -284,7 +284,13 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       const promiseRef = useRef<MutationActionCreatorResult<any>>();
 
-      useEffect(() => () => void promiseRef.current?.unsubscribe(), []);
+      useEffect(() => {
+        return () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          promiseRef.current?.unsubscribe();
+          promiseRef.current = undefined;
+        };
+      }, []);
 
       const triggerMutation = useCallback(
         function (args) {


### PR DESCRIPTION
Shrugsy reported this in Discord, and this solves it, but I haven't considered any other implications yet. Will review again later.

> Is there anything I can do about hot reloading causing queries to get unsubscribed and become 'uninitialized'? On a fresh CRA install, after adding a small rtk query setup, the behaviour I observe is like so:
> 1. Launch app (npm start)
> 2. Open console
> 3. Open redux devtools
> 4. [in devtools + console] Observe that data fetches normally (query fulfils in devtools, data & statuses populate in console)
> 5. [in ide] Edit and save this file (e.g. edit the logging text) to trigger a hot reload
> 6. [in devtools] Observe that the 'pokemonApi/subscriptions/unsubscribeResult' action is dispatched after the hot reload
> 7. [in console] Wait 60 seconds (or length of 'keepUnusedDataFor' option)
> 8. [in devtools] Observe that the 'pokemonApi/queries/removeQueryResult' action is dispatched
> 9. [in console] Observe that 'isUninitialized' is now back to true
> A repo that reproduces this is here: https://github.com/Shrugsy/simple-rtk-app
> Editing this file will allow you to reproduce it with the above steps: https://github.com/Shrugsy/simple-rtk-app/blob/master/src/features/pokemon/PokemonItem.jsx