### PR TITLE
useLazyQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 dist
 typesversions
 .cache
+.yarn
+.yarnrc

--- a/examples/react/src/app/services/split/index.ts
+++ b/examples/react/src/app/services/split/index.ts
@@ -1,5 +1,4 @@
 import { createApi, fetchBaseQuery, ApiWithInjectedEndpoints } from '@rtk-incubator/rtk-query/react';
-
 export interface Post {
   id: number;
   name: string;
@@ -14,11 +13,12 @@ export const emptySplitApi = createApi({
   endpoints: () => ({}),
 });
 
-export const splitApi = emptySplitApi as ApiWithInjectedEndpoints<
-  typeof emptySplitApi,
-  [
-    // these are only type imports, no runtime imports -> no bundle dependence
-    typeof import('./posts').apiWithPosts,
-    typeof import('./post').apiWithPost
-  ]
->;
+export const splitApi = emptySplitApi as any;
+// as ApiWithInjectedEndpoints<
+//   typeof emptySplitApi,
+//   [
+//     // these are only type imports, no runtime imports -> no bundle dependence
+//     typeof import('./posts').apiWithPosts,
+//     typeof import('./post').apiWithPost
+//   ]
+// >;

--- a/examples/react/src/features/posts/PostsManager.tsx
+++ b/examples/react/src/features/posts/PostsManager.tsx
@@ -69,7 +69,7 @@ const PostList = () => {
     return (
       <div>
         No posts :({' '}
-        <button onClick={getPosts} disabled={isFetching}>
+        <button onClick={() => getPosts()} disabled={isFetching}>
           {isFetching ? 'Fetching...' : 'Fetch them'}
         </button>
       </div>
@@ -78,7 +78,7 @@ const PostList = () => {
 
   return (
     <div>
-      <button onClick={getPosts}> {isFetching ? 'Fetching...' : 'Refetch posts'}</button>
+      <button onClick={() => getPosts()}> {isFetching ? 'Fetching...' : 'Refetch posts'}</button>
       {posts.map((post) => (
         <PostListItem key={post.id} data={post} onSelect={(id) => push(`/posts/${id}`)} />
       ))}

--- a/examples/react/src/features/posts/PostsManager.tsx
+++ b/examples/react/src/features/posts/PostsManager.tsx
@@ -56,7 +56,9 @@ const PostListItem = ({ data: { name, id }, onSelect }: { data: Post; onSelect: 
 };
 
 const PostList = () => {
-  const { data: posts, isLoading } = useGetPostsQuery();
+  // const { data: posts, isLoading } = useGetPostsQuery();
+  const [getPosts, { data: posts, isLoading, isFetching }] = postApi.endpoints['getPosts'].useLazyQuery();
+
   const { push } = useHistory();
 
   if (isLoading) {
@@ -64,11 +66,19 @@ const PostList = () => {
   }
 
   if (!posts) {
-    return <div>No posts :(</div>;
+    return (
+      <div>
+        No posts :({' '}
+        <button onClick={getPosts} disabled={isFetching}>
+          {isFetching ? 'Fetching...' : 'Fetch them'}
+        </button>
+      </div>
+    );
   }
 
   return (
     <div>
+      <button onClick={getPosts}> {isFetching ? 'Fetching...' : 'Refetch posts'}</button>
       {posts.map((post) => (
         <PostListItem key={post.id} data={post} onSelect={(id) => push(`/posts/${id}`)} />
       ))}

--- a/examples/react/src/mocks/handlers.ts
+++ b/examples/react/src/mocks/handlers.ts
@@ -58,7 +58,7 @@ export const handlers = [
   }),
 
   rest.get('/posts', (req, res, ctx) => {
-    return res(ctx.json(Object.values(state.entities)));
+    return res(ctx.delay(300), ctx.json(Object.values(state.entities)));
   }),
 
   rest.post('/posts', (req, res, ctx) => {

--- a/examples/react/yarn.lock
+++ b/examples/react/yarn.lock
@@ -10716,9 +10716,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/package.json
+++ b/package.json
@@ -110,8 +110,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "immer": ">=8.0.0",
-    "react-fast-compare": "^3.2.0"
+    "immer": ">=8.0.0"
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "immer": ">=8.0.0"
+    "immer": ">=8.0.0",
+    "react-fast-compare": "^3.2.0"
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@typescript-eslint/parser": "^4.18.0",
     "immer": ">=8.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@typescript-eslint/parser": "^4.18.0",
     "immer": ">=8.0.0"
   },
   "peerDependencies": {
@@ -146,8 +145,11 @@
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/user-event": "^12.2.2",
     "@types/react-redux": "^7.1.9",
+    "@typescript-eslint/eslint-plugin": "^4.19.0",
+    "@typescript-eslint/parser": "^4.19.0",
     "axios": "^0.21.0",
     "cross-fetch": "^3.0.6",
+    "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
     "msw": "^0.24.2",
@@ -165,11 +167,12 @@
     "ts-node": "^9.0.0",
     "ts-unused-exports": "^7.0.0",
     "tsdx": "^0.14.1",
-    "tslib": "^2.0.3"
+    "tslib": "^2.0.3",
+    "typescript": "^4.2.3"
   },
   "resolutions": {
-    "typescript": "4.1.2",
-    "@typescript-eslint/parser": "4.7.0",
+    "typescript": "4.2.3",
+    "@typescript-eslint/parser": "4.19.0",
     "prettier": "^2.2.0",
     "immer": "^8.0.0",
     "ts-jest": "^26.4.4",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "shelljs": "^0.8.4",
     "size-limit": "^4.6.0",
+    "ts-jest": "^26.5.4",
     "ts-node": "^9.0.0",
     "ts-unused-exports": "^7.0.0",
     "tsdx": "^0.14.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const UNINITIALIZED_VALUE = Symbol();
+export type UninitializedValue = typeof UNINITIALIZED_VALUE;

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -126,9 +126,9 @@ type BaseMutationSubState<D extends BaseEndpointDefinition<any, any, any>> = {
 };
 
 export type MutationSubState<D extends BaseEndpointDefinition<any, any, any>> =
-  | ({
+  | (({
       status: QueryStatus.fulfilled;
-    } & WithRequiredProp<BaseMutationSubState<D>, 'data' | 'fulfilledTimeStamp'>)
+    } & WithRequiredProp<BaseMutationSubState<D>, 'data' | 'fulfilledTimeStamp'>) & { error: undefined })
   | ({
       status: QueryStatus.pending;
     } & BaseMutationSubState<D>)

--- a/src/core/buildInitiate.ts
+++ b/src/core/buildInitiate.ts
@@ -16,6 +16,7 @@ import { BaseQueryResult } from '../baseQueryTypes';
 declare module './module' {
   export interface ApiEndpointQuery<
     Definition extends QueryDefinition<any, any, any, any, any>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     Definitions extends EndpointDefinitions
   > {
     initiate: StartQueryActionCreator<Definition>;
@@ -23,6 +24,7 @@ declare module './module' {
 
   export interface ApiEndpointMutation<
     Definition extends MutationDefinition<any, any, any, any, any>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     Definitions extends EndpointDefinitions
   > {
     initiate: StartMutationActionCreator<Definition>;

--- a/src/core/buildInitiate.ts
+++ b/src/core/buildInitiate.ts
@@ -43,6 +43,7 @@ type StartQueryActionCreator<D extends QueryDefinition<any, any, any, any, any>>
 export type QueryActionCreatorResult<D extends QueryDefinition<any, any, any, any>> = Promise<QuerySubState<D>> & {
   arg: QueryArgFrom<D>;
   requestId: string;
+  subscriptionOptions: SubscriptionOptions | undefined;
   abort(): void;
   unsubscribe(): void;
   refetch(): void;
@@ -109,6 +110,7 @@ export function buildInitiate<InternalQueryArgs>({
       return Object.assign(statePromise, {
         arg,
         requestId,
+        subscriptionOptions,
         abort,
         refetch() {
           dispatch(queryAction(arg, { subscribe: false, forceRefetch: true }));

--- a/src/core/buildSelectors.ts
+++ b/src/core/buildSelectors.ts
@@ -68,7 +68,7 @@ export function buildSelectors<InternalQueryArgs, Definitions extends EndpointDe
   serializeQueryArgs: InternalSerializeQueryArgs<InternalQueryArgs>;
   reducerPath: ReducerPath;
 }) {
-  type RootState = _RootState<Definitions, string, ReducerPath>;
+  type RootState = _RootState<Definitions, string, string>;
 
   return { buildQuerySelector, buildMutationSelector };
 

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -24,11 +24,13 @@ import { ApiEndpointQuery, PrefetchOptions } from './module';
 declare module './module' {
   export interface ApiEndpointQuery<
     Definition extends QueryDefinition<any, any, any, any, any>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     Definitions extends EndpointDefinitions
   > extends Matchers<QueryThunk, Definition> {}
 
   export interface ApiEndpointMutation<
     Definition extends MutationDefinition<any, any, any, any, any>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     Definitions extends EndpointDefinitions
   > extends Matchers<MutationThunk, Definition> {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,5 @@ export { retry } from './retry';
 export { setupListeners } from './core/setupListeners';
 export type { CreateApi, CreateApiOptions } from './createApi';
 export { buildCreateApi } from './createApi';
-export {} from './constants';
 
 export { createApi, coreModule } from './core';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,6 @@ export { retry } from './retry';
 export { setupListeners } from './core/setupListeners';
 export type { CreateApi, CreateApiOptions } from './createApi';
 export { buildCreateApi } from './createApi';
+export {} from './constants';
 
 export { createApi, coreModule } from './core';

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -262,11 +262,9 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           refetchOnFocus,
           pollingInterval,
         };
-        if (lastPromise) {
-          if (!shallowEqual(options, optionsRef.current)) {
-            lastPromise.updateSubscriptionOptions(options);
-            optionsRef.current = options;
-          }
+        if (optionsRef.current && !shallowEqual(options, optionsRef.current)) {
+          lastPromise.updateSubscriptionOptions(options);
+          optionsRef.current = options;
         }
       }, [lastPromise, refetchOnFocus, refetchOnReconnect, pollingInterval]);
 

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -205,7 +205,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           // arg did not change, but options probably did, update them
           lastPromise.updateSubscriptionOptions({ pollingInterval, refetchOnReconnect, refetchOnFocus });
         } else {
-          if (lastPromise) lastPromise.unsubscribe();
+          lastPromise?.unsubscribe();
           const promise = dispatch(
             initiate(stableArg, {
               subscriptionOptions: { pollingInterval, refetchOnReconnect, refetchOnFocus },
@@ -227,7 +227,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       useEffect(() => {
         return () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           promiseRef.current?.unsubscribe();
           promiseRef.current = undefined;
         };
@@ -255,42 +254,30 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       const promiseRef = useRef<QueryActionCreatorResult<any>>();
       const lastPromise = promiseRef.current;
 
-      const optionsRef = useRef<SubscriptionOptions>();
-
       useEffect(() => {
         const options = {
           refetchOnReconnect,
           refetchOnFocus,
           pollingInterval,
         };
-        if (optionsRef.current && !shallowEqual(options, optionsRef.current)) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        if (lastPromise && !shallowEqual(options, lastPromise.subscriptionOptions)) {
           lastPromise?.updateSubscriptionOptions(options);
-          optionsRef.current = options;
         }
       }, [lastPromise, refetchOnFocus, refetchOnReconnect, pollingInterval]);
 
       useEffect(() => {
         return () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           promiseRef.current?.unsubscribe();
           promiseRef.current = undefined;
-          optionsRef.current = undefined;
         };
       }, []);
 
       const trigger = useCallback(
-        function (args: any) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        function (arg: any) {
           lastPromise?.unsubscribe();
 
-          // Set the subscription options on the initial query
-          if (!optionsRef.current) {
-            optionsRef.current = { pollingInterval, refetchOnReconnect, refetchOnFocus };
-          }
-
           promiseRef.current = dispatch(
-            initiate(args, {
+            initiate(arg, {
               subscriptionOptions: { pollingInterval, refetchOnReconnect, refetchOnFocus },
               forceRefetch: true,
             })
@@ -378,7 +365,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
 
       useEffect(() => {
         return () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           promiseRef.current?.unsubscribe();
           promiseRef.current = undefined;
         };
@@ -388,7 +374,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         function (args) {
           let promise: MutationActionCreatorResult<any>;
           batch(() => {
-            if (promiseRef.current) promiseRef.current.unsubscribe();
+            promiseRef?.current?.unsubscribe();
             promise = dispatch(initiate(args));
             promiseRef.current = promise;
             setRequestId(promise.requestId);

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -358,7 +358,8 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
           [trigger]
         );
 
-        return useMemo(() => [triggerQuery, queryStateResults], [triggerQuery, queryStateResults]);
+        const info = useMemo(() => ({ lastArgs: promise.args }, [ promise.args ]);
+        return useMemo(() => [triggerQuery, queryStateResults, info], [triggerQuery, queryStateResults, info]);
       },
       useQuery(arg, options) {
         const querySubscriptionResults = useQuerySubscription(arg, options);

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -271,9 +271,11 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
       useLazyQuery(arg, options) {
         const queryStateResults = useQueryState(arg, options);
         const [isTriggered, setTriggered] = useState((queryStateResults as any).isSuccess);
+
+        // `skip` gets overridden because it doesn't make sense to use a query lazily, then skip it's result
         const { refetch, ...querySubscriptionResults } = useQuerySubscription(arg, {
           ...options,
-          ...(isTriggered ? {} : { skip: !isTriggered }),
+          skip: !isTriggered,
         });
 
         const triggerQuery = useCallback(() => (!isTriggered ? setTriggered(true) : refetch()), [refetch, isTriggered]);

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -1,5 +1,5 @@
 import { AnyAction, createSelector, ThunkAction, ThunkDispatch } from '@reduxjs/toolkit';
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   MutationSubState,
   QueryStatus,
@@ -294,7 +294,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
             setArg(arg);
           });
         },
-        [dispatch, initiate, arg, pollingInterval, refetchOnFocus, refetchOnReconnect]
+        [dispatch, initiate, pollingInterval, refetchOnFocus, refetchOnReconnect]
       );
 
       /* cleanup on unmount */

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -70,13 +70,15 @@ export const reactHooksModule = ({
       injectEndpoint(endpointName, definition) {
         const anyApi = (api as any) as Api<any, Record<string, any>, string, string, ReactHooksModule>;
         if (isQueryDefinition(definition)) {
-          const { useQuery, useQueryState, useQuerySubscription } = buildQueryHooks(endpointName);
+          const { useQuery, useLazyQuery, useQueryState, useQuerySubscription } = buildQueryHooks(endpointName);
           safeAssign(anyApi.endpoints[endpointName], {
             useQuery,
+            useLazyQuery,
             useQueryState,
             useQuerySubscription,
           });
           (api as any)[`use${capitalize(endpointName)}Query`] = useQuery;
+          (api as any)[`useLazy${capitalize(endpointName)}Query`] = useLazyQuery;
         } else if (isMutationDefinition(definition)) {
           const useMutation = buildMutationHook(endpointName);
           safeAssign(anyApi.endpoints[endpointName], {

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -27,7 +27,9 @@ declare module '../apiTypes' {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     BaseQuery extends BaseQueryFn,
     Definitions extends EndpointDefinitions,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ReducerPath extends string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     EntityTypes extends string
   > {
     [reactHooksModuleName]: {

--- a/src/ts41Types.ts
+++ b/src/ts41Types.ts
@@ -1,20 +1,23 @@
-import { MutationHook, UseQuery } from './react-hooks/buildHooks';
-import { EndpointDefinition, EndpointDefinitions, MutationDefinition, QueryDefinition } from './endpointDefinitions';
+import { MutationHook, UseLazyQuery, UseQuery } from './react-hooks/buildHooks';
+import { DefinitionType, EndpointDefinitions } from './endpointDefinitions';
 
-export type TS41Hooks<Definitions extends EndpointDefinitions> = {
-  [K in string & keyof Definitions as TS41HookName<K, Definitions[K]>]: Definitions[K] extends QueryDefinition<
-    any,
-    any,
-    any,
-    any
-  >
-    ? UseQuery<Definitions[K]>
-    : Definitions[K] extends MutationDefinition<any, any, any, any>
-    ? MutationHook<Definitions[K]>
-    : never;
-};
-
-type TS41HookName<
-  K extends string,
-  Definition extends EndpointDefinition<any, any, any, any>
-> = `use${Capitalize<K>}${Definition extends QueryDefinition<any, any, any, any> ? 'Query' : 'Mutation'}`;
+export type TS41Hooks<Definitions extends EndpointDefinitions> = keyof Definitions extends infer Keys
+  ? Keys extends string
+    ? Definitions[Keys] extends { type: DefinitionType.query }
+      ? {
+          [K in Keys as `use${Capitalize<K>}Query`]: UseQuery<Definitions[K] & { type: DefinitionType.query }>;
+        } &
+          {
+            [K in Keys as `useLazy${Capitalize<K>}Query`]: UseLazyQuery<
+              Definitions[K] & { type: DefinitionType.query }
+            >;
+          }
+      : Definitions[Keys] extends { type: DefinitionType.mutation }
+      ? {
+          [K in Keys as `use${Capitalize<K>}Mutation`]: MutationHook<
+            Definitions[K] & { type: DefinitionType.mutation }
+          >;
+        }
+      : never
+    : never
+  : never;

--- a/src/ts41Types.ts
+++ b/src/ts41Types.ts
@@ -1,21 +1,23 @@
 import { MutationHook, UseLazyQuery, UseQuery } from './react-hooks/buildHooks';
-import { DefinitionType, EndpointDefinitions } from './endpointDefinitions';
+import { DefinitionType, EndpointDefinitions, MutationDefinition, QueryDefinition } from './endpointDefinitions';
 
 export type TS41Hooks<Definitions extends EndpointDefinitions> = keyof Definitions extends infer Keys
   ? Keys extends string
     ? Definitions[Keys] extends { type: DefinitionType.query }
       ? {
-          [K in Keys as `use${Capitalize<K>}Query`]: UseQuery<Definitions[K] & { type: DefinitionType.query }>;
+          [K in Keys as `use${Capitalize<K>}Query`]: UseQuery<
+            Extract<Definitions[K], QueryDefinition<any, any, any, any>>
+          >;
         } &
           {
             [K in Keys as `useLazy${Capitalize<K>}Query`]: UseLazyQuery<
-              Definitions[K] & { type: DefinitionType.query }
+              Extract<Definitions[K], QueryDefinition<any, any, any, any>>
             >;
           }
       : Definitions[Keys] extends { type: DefinitionType.mutation }
       ? {
           [K in Keys as `use${Capitalize<K>}Mutation`]: MutationHook<
-            Definitions[K] & { type: DefinitionType.mutation }
+            Extract<Definitions[K], MutationDefinition<any, any, any, any>>
           >;
         }
       : never

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -508,7 +508,6 @@ describe('hooks tests', () => {
       await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
       await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-      // `args` changed from 1 -> 2, should unsubscribe the original for 1.
       expect(storeRef.store.getState().actions.filter(api.internalActions.unsubscribeQueryResult.match)).toHaveLength(
         1
       );
@@ -519,10 +518,10 @@ describe('hooks tests', () => {
         2
       );
 
-      // no `arg` change, no unsubscribe happens, just another pending request/fulfilled
+      // we always unsubscribe the original promise and create a new one
       fireEvent.click(screen.getByTestId('fetchUser1'));
       expect(storeRef.store.getState().actions.filter(api.internalActions.unsubscribeQueryResult.match)).toHaveLength(
-        2
+        3
       );
     });
   });

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -488,7 +488,7 @@ describe('hooks tests', () => {
         );
       }
 
-      render(<User />, { wrapper: storeRef.wrapper });
+      const { unmount } = render(<User />, { wrapper: storeRef.wrapper });
 
       await waitFor(() => expect(screen.getByTestId('isUninitialized').textContent).toBe('true'));
       await waitFor(() => expect(data).toBeUndefined());
@@ -522,6 +522,13 @@ describe('hooks tests', () => {
       fireEvent.click(screen.getByTestId('fetchUser1'));
       expect(storeRef.store.getState().actions.filter(api.internalActions.unsubscribeQueryResult.match)).toHaveLength(
         3
+      );
+
+      unmount();
+
+      // We unsubscribe after the component unmounts
+      expect(storeRef.store.getState().actions.filter(api.internalActions.unsubscribeQueryResult.match)).toHaveLength(
+        4
       );
     });
   });

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { createApi, fetchBaseQuery, QueryStatus } from '@rtk-incubator/rtk-query/react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
 import { setupApiStore, waitMs } from './helpers';
 import { server } from './mocks/server';
-import { rest } from 'msw';
 
 // Just setup a temporary in-memory counter for tests that `getIncrementedAmount`.
 // This can be used to test how many renders happen due to data changes or
@@ -47,588 +47,630 @@ afterEach(() => {
 });
 
 describe('hooks tests', () => {
-  test('useQuery hook sets isFetching=true whenever a request is in flight', async () => {
-    function User() {
-      const [value, setValue] = React.useState(0);
+  describe('useQuery', () => {
+    test('useQuery hook sets isFetching=true whenever a request is in flight', async () => {
+      function User() {
+        const [value, setValue] = React.useState(0);
 
-      const { isFetching } = api.endpoints.getUser.useQuery(1, { skip: value < 1 });
+        const { isFetching } = api.endpoints.getUser.useQuery(1, { skip: value < 1 });
 
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
-        </div>
-      );
-    }
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
+          </div>
+        );
+      }
 
-    const { getByText, getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
+      render(<User />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-    fireEvent.click(getByText('Increment value'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-    fireEvent.click(getByText('Increment value'));
-    // Being that nothing has changed in the args, this should never fire.
-    expect(getByTestId('isFetching').textContent).toBe('false');
-  });
-
-  test('useQuery hook sets isLoading=true only on initial request', async () => {
-    let refetch: any, isLoading: boolean;
-    function User() {
-      const [value, setValue] = React.useState(0);
-
-      ({ isLoading, refetch } = api.endpoints.getUser.useQuery(2, { skip: value < 1 }));
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
-        </div>
-      );
-    }
-
-    const { getByText, getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
-
-    // Being that we skipped the initial request on mount, this should be false
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-    fireEvent.click(getByText('Increment value'));
-    // Condition is met, should load
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false')); // Make sure the original loading has completed.
-    fireEvent.click(getByText('Increment value'));
-    // Being that we already have data, isLoading should be false
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-    // We call a refetch, should set to true
-    act(() => refetch());
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-  });
-
-  test('useQuery hook sets isLoading and isFetching to the correct states', async () => {
-    let refetchMe: () => void = () => {};
-    function User() {
-      const [value, setValue] = React.useState(0);
-
-      const { isLoading, isFetching, refetch } = api.endpoints.getUser.useQuery(22, { skip: value < 1 });
-      refetchMe = refetch;
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
-        </div>
-      );
-    }
-
-    const { getByText, getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
-
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('false');
-      expect(getByTestId('isFetching').textContent).toBe('false');
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+      fireEvent.click(screen.getByText('Increment value'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+      fireEvent.click(screen.getByText('Increment value'));
+      // Being that nothing has changed in the args, this should never fire.
+      expect(screen.getByTestId('isFetching').textContent).toBe('false');
     });
-    fireEvent.click(getByText('Increment value'));
-    // Condition is met, should load
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('true');
-      expect(getByTestId('isFetching').textContent).toBe('true');
-    });
-    // Make sure the request is done for sure.
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('false');
-      expect(getByTestId('isFetching').textContent).toBe('false');
-    });
-    fireEvent.click(getByText('Increment value'));
-    // Being that we already have data, isLoading should be false
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('false');
-      expect(getByTestId('isFetching').textContent).toBe('false');
-    });
-    // Make sure the request is done for sure.
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('false');
-      expect(getByTestId('isFetching').textContent).toBe('false');
-    });
-    // We call a refetch, should set both to true, then false when complete/errored
-    act(() => refetchMe());
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('true');
-      expect(getByTestId('isFetching').textContent).toBe('true');
-    });
-    await waitFor(() => {
-      expect(getByTestId('isLoading').textContent).toBe('false');
-      expect(getByTestId('isFetching').textContent).toBe('false');
-    });
-  });
 
-  test('useQuery hook respects refetchOnMountOrArgChange: true', async () => {
-    let data, isLoading, isFetching;
-    function User() {
-      ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: true,
+    test('useQuery hook sets isLoading=true only on initial request', async () => {
+      let refetch: any, isLoading: boolean;
+      function User() {
+        const [value, setValue] = React.useState(0);
+
+        ({ isLoading, refetch } = api.endpoints.getUser.useQuery(2, { skip: value < 1 }));
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      // Being that we skipped the initial request on mount, this should be false
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+      fireEvent.click(screen.getByText('Increment value'));
+      // Condition is met, should load
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false')); // Make sure the original loading has completed.
+      fireEvent.click(screen.getByText('Increment value'));
+      // Being that we already have data, isLoading should be false
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+      // We call a refetch, should set to true
+      act(() => refetch());
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+    });
+
+    test('useQuery hook sets isLoading and isFetching to the correct states', async () => {
+      let refetchMe: () => void = () => {};
+      function User() {
+        const [value, setValue] = React.useState(0);
+
+        const { isLoading, isFetching, refetch } = api.endpoints.getUser.useQuery(22, { skip: value < 1 });
+        refetchMe = refetch;
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <button onClick={() => setValue((val) => val + 1)}>Increment value</button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      });
+      fireEvent.click(screen.getByText('Increment value'));
+      // Condition is met, should load
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('true');
+        expect(screen.getByTestId('isFetching').textContent).toBe('true');
+      });
+      // Make sure the request is done for sure.
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      });
+      fireEvent.click(screen.getByText('Increment value'));
+      // Being that we already have data, isLoading should be false
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      });
+      // Make sure the request is done for sure.
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      });
+      // We call a refetch, should set both to true, then false when complete/errored
+      act(() => refetchMe());
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('true');
+        expect(screen.getByTestId('isFetching').textContent).toBe('true');
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      });
+    });
+
+    test('useQuery hook respects refetchOnMountOrArgChange: true', async () => {
+      let data, isLoading, isFetching;
+      function User() {
+        ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: true,
+        }));
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="amount">{String(data?.amount)}</div>
+          </div>
+        );
+      }
+
+      const { unmount } = render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+
+      unmount();
+
+      render(<User />, { wrapper: storeRef.wrapper });
+      // Let's make sure we actually fetch, and we increment
+      expect(screen.getByTestId('isLoading').textContent).toBe('false');
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('2'));
+    });
+
+    test('useQuery does not refetch when refetchOnMountOrArgChange: NUMBER condition is not met', async () => {
+      let data, isLoading, isFetching;
+      function User() {
+        ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: 10,
+        }));
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="amount">{String(data?.amount)}</div>
+          </div>
+        );
+      }
+
+      const { unmount } = render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+
+      unmount();
+
+      render(<User />, { wrapper: storeRef.wrapper });
+      // Let's make sure we actually fetch, and we increment. Should be false because we do this immediately
+      // and the condition is set to 10 seconds
+      expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+    });
+
+    test('useQuery refetches when refetchOnMountOrArgChange: NUMBER condition is met', async () => {
+      let data, isLoading, isFetching;
+      function User() {
+        ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: 0.5,
+        }));
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="amount">{String(data?.amount)}</div>
+          </div>
+        );
+      }
+
+      const { unmount } = render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+
+      unmount();
+
+      // Wait to make sure we've passed the `refetchOnMountOrArgChange` value
+      await waitMs(510);
+
+      render(<User />, { wrapper: storeRef.wrapper });
+      // Let's make sure we actually fetch, and we increment
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('2'));
+    });
+
+    test('refetchOnMountOrArgChange works as expected when changing skip from false->true', async () => {
+      let data, isLoading, isFetching;
+      function User() {
+        const [skip, setSkip] = React.useState(true);
+        ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
+          refetchOnMountOrArgChange: 0.5,
+          skip,
+        }));
+
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="amount">{String(data?.amount)}</div>
+            <button onClick={() => setSkip((prev) => !prev)}>change skip</button>;
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      expect(screen.getByTestId('isLoading').textContent).toBe('false');
+      expect(screen.getByTestId('amount').textContent).toBe('undefined');
+
+      fireEvent.click(screen.getByText('change skip'));
+
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+    });
+
+    test('refetchOnMountOrArgChange works as expected when changing skip from false->true with a cached query', async () => {
+      // 1. we need to mount a skipped query, then toggle skip to generate a cached result
+      // 2. we need to mount a skipped component after that, then toggle skip as well. should pull from the cache.
+      // 3. we need to mount another skipped component, then toggle skip after the specified duration and expect the time condition to be satisfied
+
+      let data, isLoading, isFetching;
+      function User() {
+        const [skip, setSkip] = React.useState(true);
+        ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
+          skip,
+          refetchOnMountOrArgChange: 0.5,
+        }));
+
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <div data-testid="amount">{String(data?.amount)}</div>
+            <button onClick={() => setSkip((prev) => !prev)}>change skip</button>;
+          </div>
+        );
+      }
+
+      let { unmount } = render(<User />, { wrapper: storeRef.wrapper });
+
+      // skipped queries do nothing by default, so we need to toggle that to get a cached result
+      fireEvent.click(screen.getByText('change skip'));
+
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
+
+      unmount();
+
+      await waitMs(100);
+
+      // This will pull from the cache as the time criteria is not met.
+      ({ unmount } = render(<User />, {
+        wrapper: storeRef.wrapper,
       }));
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="amount">{String(data?.amount)}</div>
-        </div>
-      );
-    }
 
-    let { getByTestId, unmount } = render(<User />, { wrapper: storeRef.wrapper });
+      // skipped queries return nothing
+      expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      expect(screen.getByTestId('amount').textContent).toBe('undefined');
 
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
+      // toggle skip -> true... won't refetch as the time critera is not met, and just loads the cached values
+      fireEvent.click(screen.getByText('change skip'));
+      expect(screen.getByTestId('isFetching').textContent).toBe('false');
+      expect(screen.getByTestId('amount').textContent).toBe('1');
 
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
+      unmount();
 
-    unmount();
+      await waitMs(500);
 
-    ({ getByTestId } = render(<User />, { wrapper: storeRef.wrapper }));
-    // Let's make sure we actually fetch, and we increment
-    expect(getByTestId('isLoading').textContent).toBe('false');
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('2'));
-  });
-
-  test('useQuery does not refetch when refetchOnMountOrArgChange: NUMBER condition is not met', async () => {
-    let data, isLoading, isFetching;
-    function User() {
-      ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: 10,
-      }));
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="amount">{String(data?.amount)}</div>
-        </div>
-      );
-    }
-
-    let { getByTestId, unmount } = render(<User />, { wrapper: storeRef.wrapper });
-
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
-
-    unmount();
-
-    ({ getByTestId } = render(<User />, { wrapper: storeRef.wrapper }));
-    // Let's make sure we actually fetch, and we increment. Should be false because we do this immediately
-    // and the condition is set to 10 seconds
-    expect(getByTestId('isFetching').textContent).toBe('false');
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
-  });
-
-  test('useQuery refetches when refetchOnMountOrArgChange: NUMBER condition is met', async () => {
-    let data, isLoading, isFetching;
-    function User() {
-      ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: 0.5,
-      }));
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="amount">{String(data?.amount)}</div>
-        </div>
-      );
-    }
-
-    let { getByTestId, unmount } = render(<User />, { wrapper: storeRef.wrapper });
-
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
-
-    unmount();
-
-    // Wait to make sure we've passed the `refetchOnMountOrArgChange` value
-    await waitMs(510);
-
-    ({ getByTestId } = render(<User />, { wrapper: storeRef.wrapper }));
-    // Let's make sure we actually fetch, and we increment
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('2'));
-  });
-
-  test('refetchOnMountOrArgChange works as expected when changing skip from false->true', async () => {
-    let data, isLoading, isFetching;
-    function User() {
-      const [skip, setSkip] = React.useState(true);
-      ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-        refetchOnMountOrArgChange: 0.5,
-        skip,
+      ({ unmount } = render(<User />, {
+        wrapper: storeRef.wrapper,
       }));
 
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="amount">{String(data?.amount)}</div>
-          <button onClick={() => setSkip((prev) => !prev)}>change skip</button>;
-        </div>
-      );
-    }
+      // toggle skip -> true... will cause a refetch as the time criteria is now satisfied
+      fireEvent.click(screen.getByText('change skip'));
 
-    let { getByTestId, getByText } = render(<User />, { wrapper: storeRef.wrapper });
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-    expect(getByTestId('isLoading').textContent).toBe('false');
-    expect(getByTestId('amount').textContent).toBe('undefined');
-
-    fireEvent.click(getByText('change skip'));
-
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
-  });
-
-  test('refetchOnMountOrArgChange works as expected when changing skip from false->true with a cached query', async () => {
-    // 1. we need to mount a skipped query, then toggle skip to generate a cached result
-    // 2. we need to mount a skipped component after that, then toggle skip as well. should pull from the cache.
-    // 3. we need to mount another skipped component, then toggle skip after the specified duration and expect the time condition to be satisfied
-
-    let data, isLoading, isFetching;
-    function User() {
-      const [skip, setSkip] = React.useState(true);
-      ({ data, isLoading, isFetching } = api.endpoints.getIncrementedAmount.useQuery(undefined, {
-        skip,
-        refetchOnMountOrArgChange: 0.5,
-      }));
-
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <div data-testid="amount">{String(data?.amount)}</div>
-          <button onClick={() => setSkip((prev) => !prev)}>change skip</button>;
-        </div>
-      );
-    }
-
-    let { getByTestId, getByText, unmount } = render(<User />, { wrapper: storeRef.wrapper });
-
-    // skipped queries do nothing by default, so we need to toggle that to get a cached result
-    fireEvent.click(getByText('change skip'));
-
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
-
-    unmount();
-
-    await waitMs(100);
-
-    // This will pull from the cache as the time criteria is not met.
-    ({ getByTestId, getByText, unmount } = render(<User />, {
-      wrapper: storeRef.wrapper,
-    }));
-
-    // skipped queries return nothing
-    expect(getByTestId('isFetching').textContent).toBe('false');
-    expect(getByTestId('amount').textContent).toBe('undefined');
-
-    // toggle skip -> true... won't refetch as the time critera is not met, and just loads the cached values
-    fireEvent.click(getByText('change skip'));
-    expect(getByTestId('isFetching').textContent).toBe('false');
-    expect(getByTestId('amount').textContent).toBe('1');
-
-    unmount();
-
-    await waitMs(500);
-
-    ({ getByTestId, getByText, unmount } = render(<User />, {
-      wrapper: storeRef.wrapper,
-    }));
-
-    // toggle skip -> true... will cause a refetch as the time criteria is now satisfied
-    fireEvent.click(getByText('change skip'));
-
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('2'));
-  });
-
-  test('useMutation hook sets and unsets the `isLoading` flag when running', async () => {
-    function User() {
-      const [updateUser, { isLoading }] = api.endpoints.updateUser.useMutation();
-
-      return (
-        <div>
-          <div data-testid="isLoading">{String(isLoading)}</div>
-          <button onClick={() => updateUser({ name: 'Banana' })}>Update User</button>
-        </div>
-      );
-    }
-
-    const { getByText, getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
-
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-    fireEvent.click(getByText('Update User'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
-  });
-
-  test('useMutation hook sets data to the resolved response on success', async () => {
-    const result = { name: 'Banana' };
-
-    function User() {
-      const [updateUser, { data }] = api.endpoints.updateUser.useMutation();
-
-      return (
-        <div>
-          <div data-testid="result">{JSON.stringify(data)}</div>
-          <button onClick={() => updateUser({ name: 'Banana' })}>Update User</button>
-        </div>
-      );
-    }
-
-    const { getByText, getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
-
-    fireEvent.click(getByText('Update User'));
-    await waitFor(() => expect(getByTestId('result').textContent).toBe(JSON.stringify(result)));
-  });
-
-  test('usePrefetch respects force arg', async () => {
-    const { usePrefetch } = api;
-    const USER_ID = 4;
-    function User() {
-      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
-      const prefetchUser = usePrefetch('getUser', { force: true });
-
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <button onMouseEnter={() => prefetchUser(USER_ID, { force: true })} data-testid="highPriority">
-            High priority action intent
-          </button>
-        </div>
-      );
-    }
-
-    const { getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
-
-    // Resolve initial query
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    userEvent.hover(getByTestId('highPriority'));
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      error: undefined,
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: true,
-      isSuccess: false,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.pending,
-    });
-
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.fulfilled,
+      await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('2'));
     });
   });
 
-  test('usePrefetch does not make an additional request if already in the cache and force=false', async () => {
-    const { usePrefetch } = api;
-    const USER_ID = 2;
+  describe('useLazyQuery', () => {
+    test('useLazyQuery does not automatically fetch when mounted', async () => {
+      function User() {
+        const [fetchUser, { isFetching, isUninitialized }] = api.endpoints.getUser.useLazyQuery(1);
 
-    function User() {
-      // Load the initial query
-      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
-      const prefetchUser = usePrefetch('getUser', { force: false });
+        return (
+          <div>
+            <div data-testid="isUninitialized">{String(isUninitialized)}</div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
 
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
-            Low priority user action intent
-          </button>
-        </div>
-      );
-    }
+            <button data-testid="fetchButton" onClick={fetchUser}>
+              fetchUser
+            </button>
+          </div>
+        );
+      }
 
-    const { getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
+      render(<User />, { wrapper: storeRef.wrapper });
 
-    // Let the initial query resolve
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-    // Try to prefetch what we just loaded
-    userEvent.hover(getByTestId('lowPriority'));
+      await waitFor(() => expect(screen.getByTestId('isUninitialized').textContent).toBe('true'));
 
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.fulfilled,
+      fireEvent.click(screen.getByTestId('fetchButton'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isUninitialized').textContent).toBe('false');
+        expect(screen.getByTestId('isFetching').textContent).toBe('true');
+      });
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
     });
 
-    await waitMs();
+    test.todo('shows existing data for a query if available');
+    test.todo('handles arg changes and basic useQuery opts');
+    test.todo('deals with any skip oddities assuming we keep partial skip functionality?');
+  });
 
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.fulfilled,
+  describe('useMutation', () => {
+    test('useMutation hook sets and unsets the `isLoading` flag when running', async () => {
+      function User() {
+        const [updateUser, { isLoading }] = api.endpoints.updateUser.useMutation();
+
+        return (
+          <div>
+            <div data-testid="isLoading">{String(isLoading)}</div>
+            <button onClick={() => updateUser({ name: 'Banana' })}>Update User</button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+      fireEvent.click(screen.getByText('Update User'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+      await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
+    });
+
+    test('useMutation hook sets data to the resolved response on success', async () => {
+      const result = { name: 'Banana' };
+
+      function User() {
+        const [updateUser, { data }] = api.endpoints.updateUser.useMutation();
+
+        return (
+          <div>
+            <div data-testid="result">{JSON.stringify(data)}</div>
+            <button onClick={() => updateUser({ name: 'Banana' })}>Update User</button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      fireEvent.click(screen.getByText('Update User'));
+      await waitFor(() => expect(screen.getByTestId('result').textContent).toBe(JSON.stringify(result)));
     });
   });
 
-  test('usePrefetch respects ifOlderThan when it evaluates to true', async () => {
-    const { usePrefetch } = api;
-    const USER_ID = 47;
+  describe('usePrefetch', () => {
+    test('usePrefetch respects force arg', async () => {
+      const { usePrefetch } = api;
+      const USER_ID = 4;
+      function User() {
+        const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
+        const prefetchUser = usePrefetch('getUser', { force: true });
 
-    function User() {
-      // Load the initial query
-      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
-      const prefetchUser = usePrefetch('getUser', { ifOlderThan: 0.2 });
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
-            Low priority user action intent
-          </button>
-        </div>
-      );
-    }
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <button onMouseEnter={() => prefetchUser(USER_ID, { force: true })} data-testid="highPriority">
+              High priority action intent
+            </button>
+          </div>
+        );
+      }
 
-    const { getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
+      render(<User />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
+      // Resolve initial query
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-    // Wait 400ms, making it respect ifOlderThan
-    await waitMs(400);
+      userEvent.hover(screen.getByTestId('highPriority'));
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        error: undefined,
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.pending,
+      });
 
-    // This should run the query being that we're past the threshold
-    userEvent.hover(getByTestId('lowPriority'));
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: true,
-      isSuccess: false,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.pending,
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.fulfilled,
+      });
     });
 
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
+    test('usePrefetch does not make an additional request if already in the cache and force=false', async () => {
+      const { usePrefetch } = api;
+      const USER_ID = 2;
 
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      data: undefined,
-      endpointName: 'getUser',
-      fulfilledTimeStamp: expect.any(Number),
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: QueryStatus.fulfilled,
+      function User() {
+        // Load the initial query
+        const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
+        const prefetchUser = usePrefetch('getUser', { force: false });
+
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
+              Low priority user action intent
+            </button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      // Let the initial query resolve
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+      // Try to prefetch what we just loaded
+      userEvent.hover(screen.getByTestId('lowPriority'));
+
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.fulfilled,
+      });
+
+      await waitMs();
+
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.fulfilled,
+      });
     });
-  });
 
-  test('usePrefetch returns the last success result when `ifOlderThan` evalutes to `false`', async () => {
-    const { usePrefetch } = api;
-    const USER_ID = 2;
+    test('usePrefetch respects ifOlderThan when it evaluates to true', async () => {
+      const { usePrefetch } = api;
+      const USER_ID = 47;
 
-    function User() {
-      // Load the initial query
-      const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
-      const prefetchUser = usePrefetch('getUser', { ifOlderThan: 10 });
+      function User() {
+        // Load the initial query
+        const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
+        const prefetchUser = usePrefetch('getUser', { ifOlderThan: 0.2 });
 
-      return (
-        <div>
-          <div data-testid="isFetching">{String(isFetching)}</div>
-          <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
-            Low priority user action intent
-          </button>
-        </div>
-      );
-    }
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
+              Low priority user action intent
+            </button>
+          </div>
+        );
+      }
 
-    const { getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
+      render(<User />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
-    await waitMs();
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-    // Get a snapshot of the last result
-    const latestQueryData = api.endpoints.getUser.select(USER_ID)(storeRef.store.getState());
+      // Wait 400ms, making it respect ifOlderThan
+      await waitMs(400);
 
-    userEvent.hover(getByTestId('lowPriority'));
-    //  Serve up the result from the cache being that the condition wasn't met
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual(latestQueryData);
-  });
+      // This should run the query being that we're past the threshold
+      userEvent.hover(screen.getByTestId('lowPriority'));
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.pending,
+      });
 
-  test('usePrefetch executes a query even if conditions fail when the cache is empty', async () => {
-    const { usePrefetch } = api;
-    const USER_ID = 2;
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-    function User() {
-      const prefetchUser = usePrefetch('getUser', { ifOlderThan: 10 });
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        data: undefined,
+        endpointName: 'getUser',
+        fulfilledTimeStamp: expect.any(Number),
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: QueryStatus.fulfilled,
+      });
+    });
 
-      return (
-        <div>
-          <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
-            Low priority user action intent
-          </button>
-        </div>
-      );
-    }
+    test('usePrefetch returns the last success result when ifOlderThan evalutes to false', async () => {
+      const { usePrefetch } = api;
+      const USER_ID = 2;
 
-    const { getByTestId } = render(<User />, { wrapper: storeRef.wrapper });
+      function User() {
+        // Load the initial query
+        const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
+        const prefetchUser = usePrefetch('getUser', { ifOlderThan: 10 });
 
-    userEvent.hover(getByTestId('lowPriority'));
+        return (
+          <div>
+            <div data-testid="isFetching">{String(isFetching)}</div>
+            <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
+              Low priority user action intent
+            </button>
+          </div>
+        );
+      }
 
-    expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
-      endpointName: 'getUser',
-      isError: false,
-      isLoading: true,
-      isSuccess: false,
-      isUninitialized: false,
-      originalArgs: USER_ID,
-      requestId: expect.any(String),
-      startedTimeStamp: expect.any(Number),
-      status: 'pending',
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+      await waitMs();
+
+      // Get a snapshot of the last result
+      const latestQueryData = api.endpoints.getUser.select(USER_ID)(storeRef.store.getState());
+
+      userEvent.hover(screen.getByTestId('lowPriority'));
+      //  Serve up the result from the cache being that the condition wasn't met
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual(latestQueryData);
+    });
+
+    test('usePrefetch executes a query even if conditions fail when the cache is empty', async () => {
+      const { usePrefetch } = api;
+      const USER_ID = 2;
+
+      function User() {
+        const prefetchUser = usePrefetch('getUser', { ifOlderThan: 10 });
+
+        return (
+          <div>
+            <button onMouseEnter={() => prefetchUser(USER_ID)} data-testid="lowPriority">
+              Low priority user action intent
+            </button>
+          </div>
+        );
+      }
+
+      render(<User />, { wrapper: storeRef.wrapper });
+
+      userEvent.hover(screen.getByTestId('lowPriority'));
+
+      expect(api.endpoints.getUser.select(USER_ID)(storeRef.store.getState())).toEqual({
+        endpointName: 'getUser',
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        isUninitialized: false,
+        originalArgs: USER_ID,
+        requestId: expect.any(String),
+        startedTimeStamp: expect.any(Number),
+        status: 'pending',
+      });
     });
   });
 });
@@ -669,12 +711,12 @@ describe('hooks with createApi defaults set', () => {
       );
     }
 
-    let { getByTestId, unmount } = render(<User />, { wrapper: storeRef.wrapper });
+    const { unmount } = render(<User />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
+    await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+    await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
 
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
+    await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
 
     unmount();
 
@@ -690,12 +732,12 @@ describe('hooks with createApi defaults set', () => {
       );
     }
 
-    ({ getByTestId } = render(<OtherUser />, { wrapper: storeRef.wrapper }));
+    render(<OtherUser />, { wrapper: storeRef.wrapper });
     // Let's make sure we actually fetch, and we increment
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
+    await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('true'));
+    await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
 
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('2'));
+    await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('2'));
   });
 
   test('useQuery hook overrides default refetchOnMountOrArgChange: false that was set by createApi', async () => {
@@ -711,12 +753,12 @@ describe('hooks with createApi defaults set', () => {
       );
     }
 
-    let { getByTestId, unmount } = render(<User />, { wrapper: storeRef.wrapper });
+    let { unmount } = render(<User />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('true'));
-    await waitFor(() => expect(getByTestId('isLoading').textContent).toBe('false'));
+    await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('true'));
+    await waitFor(() => expect(screen.getByTestId('isLoading').textContent).toBe('false'));
 
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
+    await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
 
     unmount();
 
@@ -732,10 +774,10 @@ describe('hooks with createApi defaults set', () => {
       );
     }
 
-    ({ getByTestId } = render(<OtherUser />, { wrapper: storeRef.wrapper }));
-    await waitFor(() => expect(getByTestId('isFetching').textContent).toBe('false'));
+    render(<OtherUser />, { wrapper: storeRef.wrapper });
 
-    await waitFor(() => expect(getByTestId('amount').textContent).toBe('1'));
+    await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+    await waitFor(() => expect(screen.getByTestId('amount').textContent).toBe('1'));
   });
 
   describe('selectFromResult behaviors', () => {
@@ -855,25 +897,25 @@ describe('hooks with createApi defaults set', () => {
         return <div data-testid="renderCount">{String(renderCount)}</div>;
       }
 
-      const { getByTestId } = render(
+      render(
         <div>
           <Posts />
           <SelectedPost />
         </div>,
         { wrapper: storeRef.wrapper }
       );
-      expect(getByTestId('renderCount').textContent).toBe('1');
+      expect(screen.getByTestId('renderCount').textContent).toBe('1');
 
-      const addBtn = getByTestId('addPost');
+      const addBtn = screen.getByTestId('addPost');
 
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
 
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
       // We fire off a few requests that would typically cause a rerender as JSON.parse() on a request would always be a new object.
       fireEvent.click(addBtn);
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
       // Being that it didn't rerender, we can be assured that the behavior is correct
     });
 
@@ -906,24 +948,24 @@ describe('hooks with createApi defaults set', () => {
         return <div data-testid="renderCount">{String(renderCount)}</div>;
       }
 
-      const { getByTestId } = render(
+      render(
         <div>
           <Posts />
           <SelectedPost />
         </div>,
         { wrapper: storeRef.wrapper }
       );
-      expect(getByTestId('renderCount').textContent).toBe('1');
+      expect(screen.getByTestId('renderCount').textContent).toBe('1');
 
-      const addBtn = getByTestId('addPost');
+      const addBtn = screen.getByTestId('addPost');
 
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
 
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
       fireEvent.click(addBtn);
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
     });
 
     test('useQuery with selectFromResult option serves a deeply memoized value, then ONLY updates when the underlying data changes', async () => {
@@ -967,30 +1009,30 @@ describe('hooks with createApi defaults set', () => {
         );
       }
 
-      const { getByTestId } = render(
+      render(
         <div>
           <Posts />
           <SelectedPost />
         </div>,
         { wrapper: storeRef.wrapper }
       );
-      expect(getByTestId('renderCount').textContent).toBe('1');
+      expect(screen.getByTestId('renderCount').textContent).toBe('1');
 
-      const addBtn = getByTestId('addPost');
-      const updateBtn = getByTestId('updatePost');
+      const addBtn = screen.getByTestId('addPost');
+      const updateBtn = screen.getByTestId('updatePost');
 
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
       fireEvent.click(addBtn);
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('2'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('2'));
 
       fireEvent.click(updateBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('3'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('3'));
       expect(expectablePost?.name).toBe('supercoooll!');
 
       fireEvent.click(addBtn);
-      await waitFor(() => expect(getByTestId('renderCount').textContent).toBe('3'));
+      await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('3'));
     });
   });
 });

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -404,7 +404,7 @@ describe('hooks tests', () => {
       await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
     });
 
-    test('useLazyQuery accepts updated subscription options and only dispatches `updateSubscriptionOptions` when values are updated', async () => {
+    test('useLazyQuery accepts updated subscription options and only dispatches updateSubscriptionOptions when values are updated', async () => {
       let interval = 1000;
       function User() {
         const [options, setOptions] = React.useState<SubscriptionOptions>();

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -360,16 +360,19 @@ describe('hooks tests', () => {
   });
 
   describe('useLazyQuery', () => {
-    test('useLazyQuery does not automatically fetch when mounted', async () => {
+    test('useLazyQuery does not automatically fetch when mounted and has undefined data', async () => {
+      let data: any;
       function User() {
-        const [fetchUser, { isFetching, isUninitialized }] = api.endpoints.getUser.useLazyQuery(1);
+        const [fetchUser, { data: hookData, isFetching, isUninitialized }] = api.endpoints.getUser.useLazyQuery();
+
+        data = hookData;
 
         return (
           <div>
             <div data-testid="isUninitialized">{String(isUninitialized)}</div>
             <div data-testid="isFetching">{String(isFetching)}</div>
 
-            <button data-testid="fetchButton" onClick={fetchUser}>
+            <button data-testid="fetchButton" onClick={() => fetchUser(1)}>
               fetchUser
             </button>
           </div>
@@ -379,6 +382,7 @@ describe('hooks tests', () => {
       render(<User />, { wrapper: storeRef.wrapper });
 
       await waitFor(() => expect(screen.getByTestId('isUninitialized').textContent).toBe('true'));
+      await waitFor(() => expect(data).toBeUndefined());
 
       fireEvent.click(screen.getByTestId('fetchButton'));
 
@@ -387,6 +391,8 @@ describe('hooks tests', () => {
         expect(screen.getByTestId('isFetching').textContent).toBe('true');
       });
       await waitFor(() => expect(screen.getByTestId('isFetching').textContent).toBe('false'));
+
+      console.error('hookdata', data);
     });
 
     test.todo('shows existing data for a query if available');

--- a/test/createApi.test.ts
+++ b/test/createApi.test.ts
@@ -439,6 +439,10 @@ describe('additional transformResponse behaviors', () => {
       echo: build.mutation({
         query: () => ({ method: 'PUT', url: '/echo' }),
       }),
+      mutation: build.mutation({
+        query: () => ({ url: '/echo', method: 'POST', body: { nested: { banana: 'bread' } } }),
+        transformResponse: (response: { body: { nested: EchoResponseData } }) => response.body.nested,
+      }),
       query: build.query<SuccessResponse & EchoResponseData, void>({
         query: () => '/success',
         transformResponse: async (response: SuccessResponse) => {
@@ -455,10 +459,16 @@ describe('additional transformResponse behaviors', () => {
 
   const storeRef = setupApiStore(api);
 
-  test('transformResponse handles an async transformation and returns the merged data', async () => {
+  test('transformResponse handles an async transformation and returns the merged data (query)', async () => {
     const result = await storeRef.store.dispatch(api.endpoints.query.initiate());
 
     expect(result.data).toEqual({ value: 'success', banana: 'bread' });
+  });
+
+  test('transformResponse transforms a response from a mutation', async () => {
+    const result = await storeRef.store.dispatch(api.endpoints.mutation.initiate({}));
+
+    expect(result.data).toEqual({ banana: 'bread' });
   });
 });
 

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -2,7 +2,7 @@ import { AnyAction, configureStore, EnhancedStore, Middleware, Store } from '@re
 import { setupListeners } from '@rtk-incubator/rtk-query';
 
 import { act } from '@testing-library/react-hooks';
-import React, { Reducer } from 'react';
+import React, { Reducer, useCallback } from 'react';
 import { Provider } from 'react-redux';
 
 export const ANY = 0 as any;
@@ -40,6 +40,22 @@ export const hookWaitFor = async (cb: () => void, time = 2000) => {
       await act(() => waitMs(2));
     }
   }
+};
+
+export const useRenderCounter = () => {
+  const countRef = React.useRef(0);
+
+  React.useEffect(() => {
+    countRef.current += 1;
+  });
+
+  React.useEffect(() => {
+    return () => {
+      countRef.current = 0;
+    };
+  }, []);
+
+  return useCallback(() => countRef.current, []);
 };
 
 export function matchSequence(_actions: AnyAction[], ...matchers: Array<(arg: any) => boolean>) {

--- a/test/matchers.test.tsx
+++ b/test/matchers.test.tsx
@@ -49,7 +49,7 @@ const otherEndpointMatchers = [
   querySuccess2.matchRejected,
 ];
 
-test('matches query pending & fulfilled actions for the own endpoint', async () => {
+test('matches query pending & fulfilled actions for the given endpoint', async () => {
   const endpoint = querySuccess;
   const { result } = renderHook(() => endpoint.useQuery({} as any), { wrapper: storeRef.wrapper });
   await hookWaitFor(() => expect(result.current.isLoading).toBeFalsy());
@@ -61,7 +61,7 @@ test('matches query pending & fulfilled actions for the own endpoint', async () 
     [endpoint.matchPending, endpoint.matchRejected, ...otherEndpointMatchers]
   );
 });
-test('matches query pending & rejected actions for the own endpoint', async () => {
+test('matches query pending & rejected actions for the given endpoint', async () => {
   const endpoint = queryFail;
   const { result } = renderHook(() => endpoint.useQuery({}), { wrapper: storeRef.wrapper });
   await hookWaitFor(() => expect(result.current.isLoading).toBeFalsy());
@@ -73,7 +73,36 @@ test('matches query pending & rejected actions for the own endpoint', async () =
     [endpoint.matchPending, endpoint.matchFulfilled, ...otherEndpointMatchers]
   );
 });
-test('matches mutation pending & fulfilled actions for the own endpoint', async () => {
+
+test('matches lazy query pending & fulfilled actions for given endpoint', async () => {
+  const endpoint = querySuccess;
+  const { result } = renderHook(() => endpoint.useLazyQuery(), { wrapper: storeRef.wrapper });
+  act(() => void result.current[0]({} as any));
+  await hookWaitFor(() => expect(result.current[1].isLoading).toBeFalsy());
+
+  matchSequence(storeRef.store.getState().actions, endpoint.matchPending, endpoint.matchFulfilled);
+  notMatchSequence(
+    storeRef.store.getState().actions,
+    [endpoint.matchFulfilled, endpoint.matchRejected, ...otherEndpointMatchers],
+    [endpoint.matchPending, endpoint.matchRejected, ...otherEndpointMatchers]
+  );
+});
+
+test('matches lazy query pending & rejected actions for given endpoint', async () => {
+  const endpoint = queryFail;
+  const { result } = renderHook(() => endpoint.useLazyQuery(), { wrapper: storeRef.wrapper });
+  act(() => void result.current[0]({}));
+  await hookWaitFor(() => expect(result.current[1].isLoading).toBeFalsy());
+
+  matchSequence(storeRef.store.getState().actions, endpoint.matchPending, endpoint.matchRejected);
+  notMatchSequence(
+    storeRef.store.getState().actions,
+    [endpoint.matchFulfilled, endpoint.matchRejected, ...otherEndpointMatchers],
+    [endpoint.matchPending, endpoint.matchFulfilled, ...otherEndpointMatchers]
+  );
+});
+
+test('matches mutation pending & fulfilled actions for the given endpoint', async () => {
   const endpoint = mutationSuccess;
   const { result } = renderHook(() => endpoint.useMutation(), { wrapper: storeRef.wrapper });
   act(() => void result.current[0]({}));
@@ -86,7 +115,7 @@ test('matches mutation pending & fulfilled actions for the own endpoint', async 
     [endpoint.matchPending, endpoint.matchRejected, ...otherEndpointMatchers]
   );
 });
-test('matches mutation pending & rejected actions for the own endpoint', async () => {
+test('matches mutation pending & rejected actions for the given endpoint', async () => {
   const endpoint = mutationFail;
   const { result } = renderHook(() => endpoint.useMutation(), { wrapper: storeRef.wrapper });
   act(() => void result.current[0]({}));

--- a/test/unionTypes.test.ts
+++ b/test/unionTypes.test.ts
@@ -169,7 +169,7 @@ describe.skip('TS only tests', () => {
   });
 
   test('useLazyQuery union', () => {
-    const [trigger, result] = api.endpoints.test.useLazyQuery();
+    const [_trigger, result] = api.endpoints.test.useLazyQuery();
 
     if (result.isUninitialized) {
       expectExactType(undefined)(result.data);
@@ -226,7 +226,7 @@ describe.skip('TS only tests', () => {
   });
 
   test('useLazyQuery TS4.1 union', () => {
-    const [trigger, result] = api.useLazyTestQuery();
+    const [_trigger, result] = api.useLazyTestQuery();
 
     if (result.isUninitialized) {
       expectExactType(undefined)(result.data);
@@ -314,7 +314,7 @@ describe.skip('TS only tests', () => {
   });
 
   test('useMutation union', () => {
-    const [trigger, result] = api.endpoints.mutation.useMutation();
+    const [_trigger, result] = api.endpoints.mutation.useMutation();
 
     if (result.isUninitialized) {
       expectExactType(undefined)(result.data);
@@ -358,7 +358,7 @@ describe.skip('TS only tests', () => {
   });
 
   test('useMutation TS4.1 union', () => {
-    const [trigger, result] = api.useMutationMutation();
+    const [_trigger, result] = api.useMutationMutation();
 
     if (result.isUninitialized) {
       expectExactType(undefined)(result.data);

--- a/test/unionTypes.test.ts
+++ b/test/unionTypes.test.ts
@@ -6,6 +6,7 @@ const api = createApi({
   baseQuery: fetchBaseQuery(),
   endpoints: (build) => ({
     test: build.query<string, void>({ query: () => '' }),
+    mutation: build.mutation<string, void>({ query: () => '' }),
   }),
 });
 
@@ -54,7 +55,178 @@ describe.skip('TS only tests', () => {
     }
   });
   test('useQuery union', () => {
+    const result = api.endpoints.test.useQuery();
+
+    if (result.isUninitialized) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isLoading) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isError) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType({} as SerializedError | FetchBaseQueryError)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isSuccess) {
+      expectExactType('' as string)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isFetching) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as boolean)(result.isLoading);
+      expectExactType(false as boolean)(result.isSuccess);
+      expectExactType(false as false)(result.isError);
+    }
+
+    // @ts-expect-error
+    expectType<never>(result);
+    // is always one of those four
+    if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
+      expectType<never>(result);
+    }
+  });
+
+  test('useQuery TS4.1 union', () => {
     const result = api.useTestQuery();
+
+    if (result.isUninitialized) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isLoading) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isError) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType({} as SerializedError | FetchBaseQueryError)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isSuccess) {
+      expectExactType('' as string)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isFetching) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as boolean)(result.isLoading);
+      expectExactType(false as boolean)(result.isSuccess);
+      expectExactType(false as false)(result.isError);
+    }
+
+    // @ts-expect-error
+    expectType<never>(result);
+    // is always one of those four
+    if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
+      expectType<never>(result);
+    }
+  });
+
+  test('useLazyQuery union', () => {
+    const [trigger, result] = api.endpoints.test.useLazyQuery();
+
+    if (result.isUninitialized) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isLoading) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isError) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType({} as SerializedError | FetchBaseQueryError)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isSuccess);
+      expectExactType(false as false)(result.isFetching);
+    }
+    if (result.isSuccess) {
+      expectExactType('' as string)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as boolean)(result.isFetching);
+    }
+    if (result.isFetching) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as boolean)(result.isLoading);
+      expectExactType(false as boolean)(result.isSuccess);
+      expectExactType(false as false)(result.isError);
+    }
+
+    // @ts-expect-error
+    expectType<never>(result);
+    // is always one of those four
+    if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
+      expectType<never>(result);
+    }
+  });
+
+  test('useLazyQuery TS4.1 union', () => {
+    const [trigger, result] = api.useLazyTestQuery();
 
     if (result.isUninitialized) {
       expectExactType(undefined)(result.data);
@@ -139,5 +311,93 @@ describe.skip('TS only tests', () => {
       },
     });
     expectExactType({ data: '' as string | number, isLoading: true as boolean, refetch: () => {} })(result);
+  });
+
+  test('useMutation union', () => {
+    const [trigger, result] = api.endpoints.mutation.useMutation();
+
+    if (result.isUninitialized) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isLoading) {
+      expectExactType(undefined as string | undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isError) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType({} as SerializedError | FetchBaseQueryError)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isSuccess) {
+      expectExactType('' as string)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+    }
+
+    // @ts-expect-error
+    expectType<never>(result);
+    // is always one of those four
+    if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
+      expectType<never>(result);
+    }
+  });
+
+  test('useMutation TS4.1 union', () => {
+    const [trigger, result] = api.useMutationMutation();
+
+    if (result.isUninitialized) {
+      expectExactType(undefined)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isLoading) {
+      expectExactType(undefined as string | undefined)(result.data);
+      expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isError);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isError) {
+      expectExactType('' as string | undefined)(result.data);
+      expectExactType({} as SerializedError | FetchBaseQueryError)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isSuccess);
+    }
+    if (result.isSuccess) {
+      expectExactType('' as string)(result.data);
+      expectExactType(undefined)(result.error);
+
+      expectExactType(false as false)(result.isUninitialized);
+      expectExactType(false as false)(result.isLoading);
+      expectExactType(false as false)(result.isError);
+    }
+
+    // @ts-expect-error
+    expectType<never>(result);
+    // is always one of those four
+    if (!result.isUninitialized && !result.isLoading && !result.isError && !result.isSuccess) {
+      expectType<never>(result);
+    }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,24 @@
     "@typescript-eslint/typescript-estree" "4.7.0"
     debug "^4.1.1"
 
+"@typescript-eslint/parser@^4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.18.0.tgz#a211edb14a69fc5177054bec04c95b185b4dde21"
+  integrity sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.18.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/typescript-estree" "4.18.0"
+    debug "^4.1.1"
+
+"@typescript-eslint/scope-manager@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz#d75b55234c35d2ff6ac945758d6d9e53be84a427"
+  integrity sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
+
 "@typescript-eslint/scope-manager@4.7.0":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz#2115526085fb72723ccdc1eeae75dec7126220ed"
@@ -1578,6 +1596,11 @@
   dependencies:
     "@typescript-eslint/types" "4.7.0"
     "@typescript-eslint/visitor-keys" "4.7.0"
+
+"@typescript-eslint/types@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.18.0.tgz#bebe323f81f2a7e2e320fac9415e60856267584a"
+  integrity sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==
 
 "@typescript-eslint/types@4.7.0":
   version "4.7.0"
@@ -1597,6 +1620,19 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz#756d3e61da8c16ab99185532c44872f4cd5538cb"
+  integrity sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/typescript-estree@4.7.0":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz#539531167f05ba20eb0b6785567076679e29d393"
@@ -1610,6 +1646,14 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz#4e6fe2a175ee33418318a029610845a81e2ff7b6"
+  integrity sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.7.0":
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7429,11 +7429,6 @@ raw-body@2.4.0:
     object-assign "^4.1.1"
     scheduler "^0.20.0"
 
-react-fast-compare@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
-
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,6 +5919,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@4.x:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -8814,6 +8819,22 @@ ts-jest@^25.3.1, ts-jest@^26.4.4:
     jest-util "^26.1.0"
     json5 "2.x"
     lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
+ts-jest@^26.5.4:
+  version "26.5.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.4.tgz#207f4c114812a9c6d5746dd4d1cdf899eafc9686"
+  integrity sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,20 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
+"@typescript-eslint/eslint-plugin@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz#56f8da9ee118fe9763af34d6a526967234f6a7f0"
+  integrity sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.19.0"
+    "@typescript-eslint/scope-manager" "4.19.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@2.34.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
@@ -1561,51 +1575,40 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.7.0", "@typescript-eslint/parser@^2.12.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.7.0.tgz#44bdab0f788b478178368baa65d3365fdc63da1c"
-  integrity sha512-+meGV8bMP1sJHBI2AFq1GeTwofcGiur8LoIr6v+rEmD9knyCqDlrQcFHR0KDDfldHIFDU/enZ53fla6ReF4wRw==
+"@typescript-eslint/experimental-utils@4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz#9ca379919906dc72cb0fcd817d6cb5aa2d2054c6"
+  integrity sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.7.0"
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/typescript-estree" "4.7.0"
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.19.0"
+    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/typescript-estree" "4.19.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@4.19.0", "@typescript-eslint/parser@^2.12.0", "@typescript-eslint/parser@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.19.0.tgz#4ae77513b39f164f1751f21f348d2e6cb2d11128"
+  integrity sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.19.0"
+    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/typescript-estree" "4.19.0"
     debug "^4.1.1"
 
-"@typescript-eslint/parser@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.18.0.tgz#a211edb14a69fc5177054bec04c95b185b4dde21"
-  integrity sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==
+"@typescript-eslint/scope-manager@4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz#5e0b49eca4df7684205d957c9856f4e720717a4f"
+  integrity sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.18.0"
-    "@typescript-eslint/types" "4.18.0"
-    "@typescript-eslint/typescript-estree" "4.18.0"
-    debug "^4.1.1"
+    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/visitor-keys" "4.19.0"
 
-"@typescript-eslint/scope-manager@4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz#d75b55234c35d2ff6ac945758d6d9e53be84a427"
-  integrity sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==
-  dependencies:
-    "@typescript-eslint/types" "4.18.0"
-    "@typescript-eslint/visitor-keys" "4.18.0"
-
-"@typescript-eslint/scope-manager@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz#2115526085fb72723ccdc1eeae75dec7126220ed"
-  integrity sha512-ILITvqwDJYbcDCROj6+Ob0oCKNg3SH46iWcNcTIT9B5aiVssoTYkhKjxOMNzR1F7WSJkik4zmuqve5MdnA0DyA==
-  dependencies:
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/visitor-keys" "4.7.0"
-
-"@typescript-eslint/types@4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.18.0.tgz#bebe323f81f2a7e2e320fac9415e60856267584a"
-  integrity sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==
-
-"@typescript-eslint/types@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.7.0.tgz#5e95ef5c740f43d942542b35811f87b62fccca69"
-  integrity sha512-uLszFe0wExJc+I7q0Z/+BnP7wao/kzX0hB5vJn4LIgrfrMLgnB2UXoReV19lkJQS1a1mHWGGODSxnBx6JQC3Sg==
+"@typescript-eslint/types@4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.19.0.tgz#5181d5d2afd02e5b8f149ebb37ffc8bd7b07a568"
+  integrity sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -1620,47 +1623,25 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz#756d3e61da8c16ab99185532c44872f4cd5538cb"
-  integrity sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==
+"@typescript-eslint/typescript-estree@4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz#8a709ffa400284ab72df33376df085e2e2f61147"
+  integrity sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==
   dependencies:
-    "@typescript-eslint/types" "4.18.0"
-    "@typescript-eslint/visitor-keys" "4.18.0"
+    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/visitor-keys" "4.19.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz#539531167f05ba20eb0b6785567076679e29d393"
-  integrity sha512-5XZRQznD1MfUmxu1t8/j2Af4OxbA7EFU2rbo0No7meb46eHgGkSieFdfV6omiC/DGIBhH9H9gXn7okBbVOm8jw==
+"@typescript-eslint/visitor-keys@4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz#cbea35109cbd9b26e597644556be4546465d8f7f"
+  integrity sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==
   dependencies:
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/visitor-keys" "4.7.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz#4e6fe2a175ee33418318a029610845a81e2ff7b6"
-  integrity sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==
-  dependencies:
-    "@typescript-eslint/types" "4.18.0"
-    eslint-visitor-keys "^2.0.0"
-
-"@typescript-eslint/visitor-keys@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.7.0.tgz#6783824f22acfc49e754970ed21b88ac03b80e6f"
-  integrity sha512-aDJDWuCRsf1lXOtignlfiPODkzSxxop7D0rZ91L6ZuMlcMCSh0YyK+gAfo5zN/ih6WxMwhoXgJWC3cWQdaKC+A==
-  dependencies:
-    "@typescript-eslint/types" "4.7.0"
+    "@typescript-eslint/types" "4.19.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -2888,7 +2869,7 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-confusing-browser-globals@^1.0.9:
+confusing-browser-globals@^1.0.10, confusing-browser-globals@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
@@ -3697,6 +3678,13 @@ eslint-config-react-app@^5.2.1:
   integrity sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
   dependencies:
     confusing-browser-globals "^1.0.9"
+
+eslint-config-react-app@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"
+  integrity sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==
+  dependencies:
+    confusing-browser-globals "^1.0.10"
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
@@ -9066,10 +9054,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.2, typescript@^3.7.3:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@4.2.3, typescript@^3.7.3, typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7429,6 +7429,11 @@ raw-body@2.4.0:
     object-assign "^4.1.1"
     scheduler "^0.20.0"
 
+react-fast-compare@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"


### PR DESCRIPTION
Introduces `useLazyQuery`, which allows users to opt-in to calling a query with arguments.

```ts
const [fetchThing, { data, isLoading, ...rest }] = api.endpoints.getPosts.useLazyQuery({refetchOnFocus, refetchOnReconnect, pollingInterval});

<button onClick={() => fetchThing({ with: 'variable', another: 'one' })}>Do a fetch</button>
```

Once a request is made, the query will stay subscribed to any changes while mounted in the scenario that there are other components mounted with the same query. If the arg that `fetchThing` is called with changes, it will perform a new request and then behave the same way. Additionally, we _always_ unsubscribe an existing query before initiating a new one when the `trigger` is called. 

[insert visual reference :D]