### PR TITLE
also call provides/invalidates in error cases

### DIFF
--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -1,4 +1,12 @@
-import { AsyncThunk, combineReducers, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  AsyncThunk,
+  combineReducers,
+  createSlice,
+  isAnyOf,
+  isFulfilled,
+  isRejectedWithValue,
+  PayloadAction,
+} from '@reduxjs/toolkit';
 import {
   CombinedState,
   QuerySubstateIdentifier,
@@ -14,8 +22,8 @@ import {
   SubscriptionState,
   ConfigState,
 } from './apiState';
-import type { MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks';
-import { AssertEntityTypes, calculateProvidedBy, EndpointDefinitions } from '../endpointDefinitions';
+import { calculateProvidedByThunk, MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks';
+import { AssertEntityTypes, EndpointDefinitions } from '../endpointDefinitions';
 import { applyPatches, Patch } from 'immer';
 import { onFocus, onFocusLost, onOffline, onOnline } from './setupListeners';
 import { isDocumentVisible, isOnline, copyWithStructuralSharing } from '../utils';
@@ -163,22 +171,6 @@ export function buildSlice({
     reducers: {},
     extraReducers(builder) {
       builder
-        .addCase(queryThunk.fulfilled, (draft, { payload, meta: { arg } }) => {
-          const { endpointName, queryCacheKey } = arg;
-          const providedEntities = calculateProvidedBy(
-            definitions[endpointName].provides,
-            payload.result,
-            arg.originalArgs,
-            assertEntityType
-          );
-          for (const { type, id } of providedEntities) {
-            const subscribedQueries = ((draft[type] ??= {})[id || '__internal_without_id'] ??= []);
-            const alreadySubscribed = subscribedQueries.includes(queryCacheKey);
-            if (!alreadySubscribed) {
-              subscribedQueries.push(queryCacheKey);
-            }
-          }
-        })
         .addCase(querySlice.actions.removeQueryResult, (draft, { payload: { queryCacheKey } }) => {
           for (const entityTypeSubscriptions of Object.values(draft)) {
             for (const idSubscriptions of Object.values(entityTypeSubscriptions)) {
@@ -186,6 +178,18 @@ export function buildSlice({
               if (foundAt !== -1) {
                 idSubscriptions.splice(foundAt, 1);
               }
+            }
+          }
+        })
+        .addMatcher(isAnyOf(isFulfilled(queryThunk), isRejectedWithValue(queryThunk)), (draft, action) => {
+          const providedEntities = calculateProvidedByThunk(action, 'provides', definitions, assertEntityType);
+          const { queryCacheKey } = action.meta.arg;
+
+          for (const { type, id } of providedEntities) {
+            const subscribedQueries = ((draft[type] ??= {})[id || '__internal_without_id'] ??= []);
+            const alreadySubscribed = subscribedQueries.includes(queryCacheKey);
+            if (!alreadySubscribed) {
+              subscribedQueries.push(queryCacheKey);
             }
           }
         });

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -1,6 +1,6 @@
 import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
 import { RootState } from './core/apiState';
-import { BaseQueryExtraOptions, BaseQueryFn, BaseQueryResult, BaseQueryArg } from './baseQueryTypes';
+import { BaseQueryExtraOptions, BaseQueryFn, BaseQueryResult, BaseQueryError, BaseQueryArg } from './baseQueryTypes';
 import { fetchBaseQuery } from './fetchBaseQuery';
 import { HasRequiredProps } from './tsHelpers';
 
@@ -24,16 +24,17 @@ export enum DefinitionType {
   mutation = 'mutation',
 }
 
-type GetResultDescriptionFn<EntityTypes extends string, ResultType, QueryArg> = (
-  result: ResultType,
+type GetResultDescriptionFn<EntityTypes extends string, ResultType, QueryArg, ErrorType> = (
+  result: ResultType | undefined,
+  error: ErrorType | undefined,
   arg: QueryArg
 ) => ReadonlyArray<EntityDescription<EntityTypes>>;
 
 export type FullEntityDescription<EntityType> = { type: EntityType; id?: number | string };
 type EntityDescription<EntityType> = EntityType | FullEntityDescription<EntityType>;
-type ResultDescription<EntityTypes extends string, ResultType, QueryArg> =
+type ResultDescription<EntityTypes extends string, ResultType, QueryArg, ErrorType> =
   | ReadonlyArray<EntityDescription<EntityTypes>>
-  | GetResultDescriptionFn<EntityTypes, ResultType, QueryArg>;
+  | GetResultDescriptionFn<EntityTypes, ResultType, QueryArg, ErrorType>;
 
 export interface QueryApi<ReducerPath extends string, Context extends {}> {
   dispatch: ThunkDispatch<any, any, AnyAction>;
@@ -52,7 +53,7 @@ export type QueryDefinition<
   Context = Record<string, any>
 > = BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> & {
   type: DefinitionType.query;
-  provides?: ResultDescription<EntityTypes, ResultType, QueryArg>;
+  provides?: ResultDescription<EntityTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   invalidates?: never;
   onStart?(arg: QueryArg, queryApi: QueryApi<ReducerPath, Context>): void;
   onError?(arg: QueryArg, queryApi: QueryApi<ReducerPath, Context>, error: unknown): void;
@@ -76,7 +77,7 @@ export type MutationDefinition<
   Context = Record<string, any>
 > = BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> & {
   type: DefinitionType.mutation;
-  invalidates?: ResultDescription<EntityTypes, ResultType, QueryArg>;
+  invalidates?: ResultDescription<EntityTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   provides?: never;
   onStart?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>): void;
   onError?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>, error: unknown): void;
@@ -116,14 +117,17 @@ export type EndpointBuilder<BaseQuery extends BaseQueryFn, EntityTypes extends s
 
 export type AssertEntityTypes = <T extends FullEntityDescription<string>>(t: T) => T;
 
-export function calculateProvidedBy<ResultType, QueryArg>(
-  description: ResultDescription<string, ResultType, QueryArg> | undefined,
-  result: ResultType,
+export function calculateProvidedBy<ResultType, QueryArg, ErrorType>(
+  description: ResultDescription<string, ResultType, QueryArg, ErrorType> | undefined,
+  result: ResultType | undefined,
+  error: ErrorType | undefined,
   queryArg: QueryArg,
   assertEntityTypes: AssertEntityTypes
 ): readonly FullEntityDescription<string>[] {
   if (isFunction(description)) {
-    return description(result, queryArg).map(expandEntityDescription).map(assertEntityTypes);
+    return description(result as ResultType, error as undefined, queryArg)
+      .map(expandEntityDescription)
+      .map(assertEntityTypes);
   }
   if (Array.isArray(description)) {
     return description.map(expandEntityDescription).map(assertEntityTypes);

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -798,7 +798,7 @@ describe('hooks with createApi defaults set', () => {
       endpoints: (build) => ({
         getPosts: build.query<PostsResponse, void>({
           query: () => ({ url: 'posts' }),
-          provides: (result) => [...result.map(({ id }) => ({ type: 'Posts', id } as const))],
+          provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
         }),
         updatePost: build.mutation<Post, Partial<Post>>({
           query: ({ id, ...body }) => ({
@@ -806,7 +806,7 @@ describe('hooks with createApi defaults set', () => {
             method: 'PUT',
             body,
           }),
-          invalidates: ({ id }) => [{ type: 'Posts', id }],
+          invalidates: (result) => (result ? [{ type: 'Posts', id: result.id }] : []),
         }),
         addPost: build.mutation<Post, Partial<Post>>({
           query: (body) => ({


### PR DESCRIPTION
This adresses #170.

It is at the moment of writing a **breaking change** as it changes the signature of invalidates/provides from `(result, args) => Entities` to `(result?, error?, args) => Entities`.

It only triggers on **handled errors**, which means a simple `throw` in the `baseQuery` would pass by this, only an error returned by returning `{ error: ... }` from `baseQuery` would lead to this.