### PR TITLE
Add `utils.resetApiState`

### DIFF
--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -31,11 +31,11 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   assertEntityType: AssertEntityTypes;
 }) {
   type MWApi = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerPath>>;
-
-  const currentRemovalTimeouts: QueryStateMeta<TimeoutId> = {};
   const { removeQueryResult, unsubscribeQueryResult, updateSubscriptionOptions, resetApiState } = api.internalActions;
 
+  const currentRemovalTimeouts: QueryStateMeta<TimeoutId> = {};
   const currentPolls: QueryStateMeta<{ nextPollTimestamp: number; timeout?: TimeoutId; pollingInterval: number }> = {};
+
   const middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>> = (
     mwApi
   ) => (next) => (action) => {
@@ -75,19 +75,13 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     }
 
     if (resetApiState.match(action)) {
-      for (const queryCacheKey in currentPolls) {
-        const currentTimeout = currentPolls[queryCacheKey]?.timeout;
-        if (currentTimeout) {
-          clearTimeout(currentTimeout);
-        }
-        delete currentPolls[queryCacheKey];
+      for (const [key, poll] of Object.entries(currentPolls)) {
+        if (poll?.timeout) clearTimeout(poll.timeout);
+        delete currentPolls[key];
       }
-      for (const queryCacheKey in currentRemovalTimeouts) {
-        const currentTimeout = currentRemovalTimeouts[queryCacheKey];
-        if (currentTimeout) {
-          clearTimeout(currentTimeout);
-        }
-        delete currentRemovalTimeouts[queryCacheKey];
+      for (const [key, timeout] of Object.entries(currentRemovalTimeouts)) {
+        if (timeout) clearTimeout(timeout);
+        delete currentRemovalTimeouts[key];
       }
     }
 

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -1,12 +1,4 @@
-import {
-  AnyAction,
-  AsyncThunk,
-  combineReducers,
-  createAction,
-  createSlice,
-  PayloadAction,
-  Reducer,
-} from '@reduxjs/toolkit';
+import { AsyncThunk, combineReducers, createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import {
   CombinedState,
   QuerySubstateIdentifier,

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -51,8 +51,6 @@ function updateMutationSubstateIfExists(
   }
 }
 
-const resetApiState = createAction('__rtkq/resetApiState');
-
 const initialState = {} as any;
 
 export function buildSlice({
@@ -70,6 +68,7 @@ export function buildSlice({
   assertEntityType: AssertEntityTypes;
   config: Omit<ConfigState<string>, 'online' | 'focused'>;
 }) {
+  const resetApiState = createAction(`${reducerPath}/resetApiState`);
   const querySlice = createSlice({
     name: `${reducerPath}/queries`,
     initialState: initialState as QueryState<any>,
@@ -275,18 +274,16 @@ export function buildSlice({
     },
   });
 
-  const reducer: Reducer<CombinedState<any, string, string>, AnyAction> = (state, action) => {
-    if (resetApiState.match(action)) {
-      state = undefined;
-    }
-    return combineReducers({
-      queries: querySlice.reducer,
-      mutations: mutationSlice.reducer,
-      provided: invalidationSlice.reducer,
-      subscriptions: subscriptionSlice.reducer,
-      config: configSlice.reducer,
-    })(state, action);
-  };
+  const combinedReducer = combineReducers<CombinedState<any, string, string>>({
+    queries: querySlice.reducer,
+    mutations: mutationSlice.reducer,
+    provided: invalidationSlice.reducer,
+    subscriptions: subscriptionSlice.reducer,
+    config: configSlice.reducer,
+  });
+
+  const reducer: typeof combinedReducer = (state, action) =>
+    combinedReducer(resetApiState.match(action) ? undefined : state, action);
 
   const actions = {
     updateSubscriptionOptions: subscriptionSlice.actions.updateSubscriptionOptions,

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -1,4 +1,12 @@
-import { AsyncThunk, combineReducers, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  AnyAction,
+  AsyncThunk,
+  combineReducers,
+  createAction,
+  createSlice,
+  PayloadAction,
+  Reducer,
+} from '@reduxjs/toolkit';
 import {
   CombinedState,
   QuerySubstateIdentifier,
@@ -43,6 +51,10 @@ function updateMutationSubstateIfExists(
   }
 }
 
+const resetApiState = createAction('__rtkq/resetApiState');
+
+const initialState = {} as any;
+
 export function buildSlice({
   reducerPath,
   queryThunk,
@@ -60,7 +72,7 @@ export function buildSlice({
 }) {
   const querySlice = createSlice({
     name: `${reducerPath}/queries`,
-    initialState: {} as QueryState<any>,
+    initialState: initialState as QueryState<any>,
     reducers: {
       removeQueryResult(draft, { payload: { queryCacheKey } }: PayloadAction<QuerySubstateIdentifier>) {
         delete draft[queryCacheKey];
@@ -117,7 +129,7 @@ export function buildSlice({
   });
   const mutationSlice = createSlice({
     name: `${reducerPath}/mutations`,
-    initialState: {} as MutationState<any>,
+    initialState: initialState as MutationState<any>,
     reducers: {
       unsubscribeResult(draft, action: PayloadAction<MutationSubstateIdentifier>) {
         if (action.payload.requestId in draft) {
@@ -159,7 +171,7 @@ export function buildSlice({
 
   const invalidationSlice = createSlice({
     name: `${reducerPath}/invalidation`,
-    initialState: {} as InvalidationState<string>,
+    initialState: initialState as InvalidationState<string>,
     reducers: {},
     extraReducers(builder) {
       builder
@@ -194,7 +206,7 @@ export function buildSlice({
 
   const subscriptionSlice = createSlice({
     name: `${reducerPath}/subscriptions`,
-    initialState: {} as SubscriptionState,
+    initialState: initialState as SubscriptionState,
     reducers: {
       updateSubscriptionOptions(
         draft,
@@ -263,13 +275,18 @@ export function buildSlice({
     },
   });
 
-  const reducer = combineReducers<CombinedState<any, string, string>>({
-    queries: querySlice.reducer,
-    mutations: mutationSlice.reducer,
-    provided: invalidationSlice.reducer,
-    subscriptions: subscriptionSlice.reducer,
-    config: configSlice.reducer,
-  });
+  const reducer: Reducer<CombinedState<any, string, string>, AnyAction> = (state, action) => {
+    if (resetApiState.match(action)) {
+      state = undefined;
+    }
+    return combineReducers({
+      queries: querySlice.reducer,
+      mutations: mutationSlice.reducer,
+      provided: invalidationSlice.reducer,
+      subscriptions: subscriptionSlice.reducer,
+      config: configSlice.reducer,
+    })(state, action);
+  };
 
   const actions = {
     updateSubscriptionOptions: subscriptionSlice.actions.updateSubscriptionOptions,
@@ -277,6 +294,7 @@ export function buildSlice({
     removeQueryResult: querySlice.actions.removeQueryResult,
     unsubscribeQueryResult: subscriptionSlice.actions.unsubscribeResult,
     unsubscribeMutationResult: mutationSlice.actions.unsubscribeResult,
+    resetApiState,
   };
 
   return { reducer, actions };

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -55,6 +55,7 @@ declare module '../apiTypes' {
         ): ThunkAction<void, any, any, AnyAction>;
         updateQueryResult: UpdateQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
         patchQueryResult: PatchQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+        resetApiState: SliceActions['resetApiState'];
       };
       // If you actually care about the return value, use useQuery
       usePrefetch<EndpointName extends QueryKeys<Definitions>>(
@@ -165,7 +166,12 @@ export const coreModule = (): Module<CoreModule> => ({
       config: { refetchOnFocus, refetchOnReconnect, refetchOnMountOrArgChange, keepUnusedDataFor, reducerPath },
     });
 
-    safeAssign(api.util, { patchQueryResult, updateQueryResult, prefetchThunk });
+    safeAssign(api.util, {
+      patchQueryResult,
+      updateQueryResult,
+      prefetchThunk,
+      resetApiState: sliceActions.resetApiState,
+    });
     safeAssign(api.internalActions, sliceActions);
 
     const { middleware } = buildMiddleware({

--- a/test/buildSlice.test.ts
+++ b/test/buildSlice.test.ts
@@ -69,7 +69,7 @@ it('only resets the api state when resetApiState is dispatched', async () => {
     },
   });
 
-  storeRef.store.dispatch(api.internalActions.resetApiState());
+  storeRef.store.dispatch(api.util.resetApiState());
 
   expect(storeRef.store.getState()).toEqual(initialState);
 });

--- a/test/buildSlice.test.ts
+++ b/test/buildSlice.test.ts
@@ -1,0 +1,75 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { createApi } from '@rtk-incubator/rtk-query/react';
+import { setupApiStore } from './helpers';
+
+const baseQuery = (args?: any) => ({ data: args });
+const api = createApi({
+  baseQuery,
+  endpoints: (build) => ({
+    getUser: build.query<unknown, number>({
+      query(id) {
+        return { url: `user/${id}` };
+      },
+    }),
+  }),
+});
+const { getUser } = api.endpoints;
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: {
+    token: '1234',
+  },
+  reducers: {
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+  },
+});
+
+const storeRef = setupApiStore(api, { auth: authSlice.reducer });
+
+it('only resets the api state when resetApiState is dispatched', async () => {
+  const initialState = storeRef.store.getState();
+
+  await storeRef.store.dispatch(getUser.initiate(1, { subscriptionOptions: { pollingInterval: 10 } }));
+
+  expect(storeRef.store.getState()).toEqual({
+    api: {
+      config: {
+        focused: true,
+        keepUnusedDataFor: 60,
+        online: true,
+        reducerPath: 'api',
+        refetchOnFocus: false,
+        refetchOnMountOrArgChange: false,
+        refetchOnReconnect: false,
+      },
+      mutations: {},
+      provided: {},
+      queries: {
+        'getUser(1)': {
+          data: {
+            url: 'user/1',
+          },
+          endpointName: 'getUser',
+          fulfilledTimeStamp: expect.any(Number),
+          originalArgs: 1,
+          requestId: expect.any(String),
+          startedTimeStamp: expect.any(Number),
+          status: 'fulfilled',
+        },
+      },
+      subscriptions: {
+        'getUser(1)': expect.any(Object),
+      },
+    },
+    auth: {
+      token: '1234',
+    },
+  });
+
+  storeRef.store.dispatch(api.internalActions.resetApiState());
+
+  expect(storeRef.store.getState()).toEqual(initialState);
+});


### PR DESCRIPTION
Let's a user `dispatch(api.internalActions.resetApiState())` at any point. Clears the state, cleans up any timeouts.