### PR TITLE
Add `utils.invalidateEntities`

### DIFF
--- a/src/core/buildInitiate.ts
+++ b/src/core/buildInitiate.ts
@@ -81,7 +81,7 @@ export function buildInitiate<InternalQueryArgs>({
   serializeQueryArgs: InternalSerializeQueryArgs<InternalQueryArgs>;
   queryThunk: AsyncThunk<any, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<any, MutationThunkArg<any>, {}>;
-  api: Api<any, EndpointDefinitions, any, string>;
+  api: Api<any, EndpointDefinitions, any, any>;
 }) {
   const { unsubscribeQueryResult, unsubscribeMutationResult, updateSubscriptionOptions } = api.internalActions;
   return { buildInitiateQuery, buildInitiateMutation };

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -1,4 +1,4 @@
-import { AnyAction, AsyncThunk, Middleware, MiddlewareAPI, ThunkDispatch } from '@reduxjs/toolkit';
+import { AnyAction, AsyncThunk, createAction, Middleware, MiddlewareAPI, ThunkDispatch } from '@reduxjs/toolkit';
 import { QueryCacheKey, QueryStatus, QuerySubState, QuerySubstateIdentifier, RootState, Subscribers } from './apiState';
 import { Api, ApiContext } from '../apiTypes';
 import { MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks';
@@ -31,11 +31,15 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   assertEntityType: AssertEntityTypes;
 }) {
   type MWApi = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerPath>>;
-
   const currentRemovalTimeouts: QueryStateMeta<TimeoutId> = {};
   const { removeQueryResult, unsubscribeQueryResult, updateSubscriptionOptions } = api.internalActions;
 
   const currentPolls: QueryStateMeta<{ nextPollTimestamp: number; timeout?: TimeoutId; pollingInterval: number }> = {};
+
+  const actions = {
+    invalidateEntities: createAction<any[]>('__rtkq/invalidateEntities'),
+  };
+
   const middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>> = (
     mwApi
   ) => (next) => (action) => {
@@ -51,6 +55,10 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
         ),
         mwApi
       );
+    }
+
+    if (actions.invalidateEntities.match(action)) {
+      invalidateEntities(calculateProvidedBy(action.payload, undefined, undefined, assertEntityType), mwApi);
     }
 
     if (unsubscribeQueryResult.match(action)) {
@@ -77,7 +85,7 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
     return result;
   };
 
-  return { middleware };
+  return { middleware, actions };
 
   function refetchQuery(
     querySubState: Exclude<QuerySubState<any>, { status: QueryStatus.uninitialized }>,

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -14,7 +14,11 @@ import { flatten } from '../utils';
 type QueryStateMeta<T> = Record<string, undefined | T>;
 type TimeoutId = ReturnType<typeof setTimeout>;
 
-export function buildMiddleware<Definitions extends EndpointDefinitions, ReducerPath extends string>({
+export function buildMiddleware<
+  Definitions extends EndpointDefinitions,
+  ReducerPath extends string,
+  EntityTypes extends string
+>({
   reducerPath,
   context,
   context: { endpointDefinitions },
@@ -27,7 +31,7 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   context: ApiContext<Definitions>;
   queryThunk: AsyncThunk<ThunkResult, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<ThunkResult, MutationThunkArg<any>, {}>;
-  api: Api<any, EndpointDefinitions, ReducerPath, string>;
+  api: Api<any, EndpointDefinitions, ReducerPath, EntityTypes>;
   assertEntityType: AssertEntityTypes;
 }) {
   type MWApi = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerPath>>;
@@ -37,7 +41,9 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   const currentPolls: QueryStateMeta<{ nextPollTimestamp: number; timeout?: TimeoutId; pollingInterval: number }> = {};
 
   const actions = {
-    invalidateEntities: createAction<any[]>('__rtkq/invalidateEntities'),
+    invalidateEntities: createAction<Array<EntityTypes | FullEntityDescription<EntityTypes>>>(
+      `${reducerPath}/invalidateEntities`
+    ),
   };
 
   const middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>> = (

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -133,7 +133,7 @@ export function buildThunks<
   reducerPath: ReducerPath;
   context: ApiContext<Definitions>;
   serializeQueryArgs: InternalSerializeQueryArgs<BaseQueryArg<BaseQuery>>;
-  api: Api<BaseQuery, EndpointDefinitions, ReducerPath, string>;
+  api: Api<BaseQuery, EndpointDefinitions, ReducerPath, any>;
 }) {
   type InternalQueryArgs = BaseQueryArg<BaseQuery>;
   type State = RootState<any, string, ReducerPath>;

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -45,7 +45,7 @@ declare module '../apiTypes' {
   > {
     [coreModuleName]: {
       reducerPath: ReducerPath;
-      internalActions: InternalActions<EntityTypes>;
+      internalActions: InternalActions;
       reducer: Reducer<CombinedState<Definitions, EntityTypes, ReducerPath>, AnyAction>;
       middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>>;
       util: {
@@ -56,6 +56,7 @@ declare module '../apiTypes' {
         ): ThunkAction<void, any, any, AnyAction>;
         updateQueryResult: UpdateQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
         patchQueryResult: PatchQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+        invalidateEntities: ActionCreatorWithPayload<Array<EntityTypes | FullEntityDescription<EntityTypes>>, string>;
       };
       // If you actually care about the return value, use useQuery
       usePrefetch<EndpointName extends QueryKeys<Definitions>>(
@@ -103,13 +104,7 @@ export type ListenerActions = {
   onFocusLost: typeof onFocusLost;
 };
 
-export type MiddlewareActions<EntityTypes extends string> = {
-  invalidateEntities: ActionCreatorWithPayload<Array<EntityTypes | FullEntityDescription<EntityTypes>>, string>;
-};
-
-export type InternalActions<EntityTypes extends string> = SliceActions &
-  ListenerActions &
-  MiddlewareActions<EntityTypes>;
+export type InternalActions = SliceActions & ListenerActions;
 
 export const coreModule = (): Module<CoreModule> => ({
   name: coreModuleName,
@@ -161,7 +156,7 @@ export const coreModule = (): Module<CoreModule> => ({
       baseQuery,
       reducerPath,
       context,
-      api: api as any,
+      api,
       serializeQueryArgs,
     });
 
@@ -182,10 +177,10 @@ export const coreModule = (): Module<CoreModule> => ({
       context,
       queryThunk,
       mutationThunk,
-      api: api as any,
+      api,
       assertEntityType,
     });
-    safeAssign(api.internalActions, sliceActions, middlewareActions);
+    safeAssign(api.util, middlewareActions);
 
     safeAssign(api, { reducer: reducer as any, middleware });
 
@@ -197,7 +192,7 @@ export const coreModule = (): Module<CoreModule> => ({
     const { buildInitiateQuery, buildInitiateMutation } = buildInitiate({
       queryThunk,
       mutationThunk,
-      api: api as any,
+      api,
       serializeQueryArgs: serializeQueryArgs as any,
     });
 

--- a/src/react-hooks/ApiProvider.tsx
+++ b/src/react-hooks/ApiProvider.tsx
@@ -10,7 +10,7 @@ import { Api } from '../apiTypes';
  * conflict with each other - please use the traditional redux setup
  * in that case.
  */
-export function ApiProvider<A extends Api<any, {}, any, string>>(props: {
+export function ApiProvider<A extends Api<any, {}, any, any>>(props: {
   children: any;
   api: A;
   setupListeners?: Parameters<typeof setupListeners>[1];

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -148,7 +148,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
   api,
   moduleOptions: { batch, useDispatch, useSelector },
 }: {
-  api: Api<any, Definitions, any, string, CoreModule>;
+  api: Api<any, Definitions, any, any, CoreModule>;
   moduleOptions: Required<ReactHooksModuleOptions>;
 }) {
   return { buildQueryHooks, buildMutationHook, usePrefetch };

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -60,7 +60,7 @@ export const reactHooksModule = ({
   name: reactHooksModuleName,
   init(api, options, context) {
     const { buildQueryHooks, buildMutationHook, usePrefetch } = buildHooks({
-      api,
+      api: api as any,
       moduleOptions: { batch, useDispatch, useSelector, useStore },
     });
     safeAssign(api, { usePrefetch });

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -60,7 +60,7 @@ export const reactHooksModule = ({
   name: reactHooksModuleName,
   init(api, options, context) {
     const { buildQueryHooks, buildMutationHook, usePrefetch } = buildHooks({
-      api: api as any,
+      api,
       moduleOptions: { batch, useDispatch, useSelector, useStore },
     });
     safeAssign(api, { usePrefetch });

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -509,7 +509,7 @@ describe('hooks tests', () => {
     });
   });
 
-  test('usePrefetch respects `ifOlderThan` when it evaluates to `true`', async () => {
+  test('usePrefetch respects ifOlderThan when it evaluates to true', async () => {
     const { usePrefetch } = api;
     const USER_ID = 47;
 
@@ -517,7 +517,6 @@ describe('hooks tests', () => {
       // Load the initial query
       const { isFetching } = api.endpoints.getUser.useQuery(USER_ID);
       const prefetchUser = usePrefetch('getUser', { ifOlderThan: 0.2 });
-
       return (
         <div>
           <div data-testid="isFetching">{String(isFetching)}</div>

--- a/test/buildMiddleware.test.tsx
+++ b/test/buildMiddleware.test.tsx
@@ -1,0 +1,82 @@
+import { createApi } from '@rtk-incubator/rtk-query/react';
+import { actionsReducer, matchSequence, setupApiStore, waitMs } from './helpers';
+
+const baseQuery = (args?: any) => ({ data: args });
+const api = createApi({
+  baseQuery,
+  entityTypes: ['Banana', 'Bread'],
+  endpoints: (build) => ({
+    getBanana: build.query<unknown, number>({
+      query(id) {
+        return { url: `banana/${id}` };
+      },
+      provides: ['Banana'],
+    }),
+    getBread: build.query<unknown, number>({
+      query(id) {
+        return { url: `bread/${id}` };
+      },
+      provides: ['Bread'],
+    }),
+  }),
+});
+const { getBanana, getBread } = api.endpoints;
+
+const storeRef = setupApiStore(api, {
+  ...actionsReducer,
+});
+
+it('invalidates the specified entities', async () => {
+  await storeRef.store.dispatch(getBanana.initiate(1));
+  matchSequence(storeRef.store.getState().actions, getBanana.matchPending, getBanana.matchFulfilled);
+
+  await storeRef.store.dispatch(api.internalActions.invalidateEntities(['Banana', 'Bread']));
+
+  // Slight pause to let the middleware run and such
+  await waitMs(20);
+
+  const firstSequence = [
+    getBanana.matchPending,
+    getBanana.matchFulfilled,
+    api.internalActions.invalidateEntities.match,
+    getBanana.matchPending,
+    getBanana.matchFulfilled,
+  ];
+  matchSequence(storeRef.store.getState().actions, ...firstSequence);
+
+  await storeRef.store.dispatch(getBread.initiate(1));
+  await storeRef.store.dispatch(api.internalActions.invalidateEntities([{ type: 'Bread' }]));
+
+  await waitMs(20);
+
+  matchSequence(
+    storeRef.store.getState().actions,
+    ...firstSequence,
+    getBread.matchPending,
+    getBread.matchFulfilled,
+    api.internalActions.invalidateEntities.match,
+    getBread.matchPending,
+    getBread.matchFulfilled
+  );
+});
+
+describe.skip('TS only tests', () => {
+  it('should allow for an array of string EntityTypes', () => {
+    api.internalActions.invalidateEntities(['Banana', 'Bread']);
+  });
+  it('should allow for an array of full EntityTypes descriptions', () => {
+    api.internalActions.invalidateEntities([{ type: 'Banana' }, { type: 'Bread', id: 1 }]);
+  });
+
+  it('should allow for a mix of full descriptions as well as plain strings', () => {
+    api.internalActions.invalidateEntities(['Banana', { type: 'Bread', id: 1 }]);
+  });
+  it('should error when using non-existing EntityTypes', () => {
+    // @ts-expect-error
+    api.internalActions.invalidateEntities(['Missing Entity']);
+  });
+  it('should error when using non-existing EntityTypes in the full format', () => {
+    // @ts-expect-error
+    api.internalActions.invalidateEntities([{ type: 'Missing' }]);
+  });
+});

--- a/test/buildMiddleware.test.tsx
+++ b/test/buildMiddleware.test.tsx
@@ -30,7 +30,7 @@ it('invalidates the specified entities', async () => {
   await storeRef.store.dispatch(getBanana.initiate(1));
   matchSequence(storeRef.store.getState().actions, getBanana.matchPending, getBanana.matchFulfilled);
 
-  await storeRef.store.dispatch(api.internalActions.invalidateEntities(['Banana', 'Bread']));
+  await storeRef.store.dispatch(api.util.invalidateEntities(['Banana', 'Bread']));
 
   // Slight pause to let the middleware run and such
   await waitMs(20);
@@ -38,14 +38,14 @@ it('invalidates the specified entities', async () => {
   const firstSequence = [
     getBanana.matchPending,
     getBanana.matchFulfilled,
-    api.internalActions.invalidateEntities.match,
+    api.util.invalidateEntities.match,
     getBanana.matchPending,
     getBanana.matchFulfilled,
   ];
   matchSequence(storeRef.store.getState().actions, ...firstSequence);
 
   await storeRef.store.dispatch(getBread.initiate(1));
-  await storeRef.store.dispatch(api.internalActions.invalidateEntities([{ type: 'Bread' }]));
+  await storeRef.store.dispatch(api.util.invalidateEntities([{ type: 'Bread' }]));
 
   await waitMs(20);
 
@@ -54,7 +54,7 @@ it('invalidates the specified entities', async () => {
     ...firstSequence,
     getBread.matchPending,
     getBread.matchFulfilled,
-    api.internalActions.invalidateEntities.match,
+    api.util.invalidateEntities.match,
     getBread.matchPending,
     getBread.matchFulfilled
   );
@@ -62,21 +62,21 @@ it('invalidates the specified entities', async () => {
 
 describe.skip('TS only tests', () => {
   it('should allow for an array of string EntityTypes', () => {
-    api.internalActions.invalidateEntities(['Banana', 'Bread']);
+    api.util.invalidateEntities(['Banana', 'Bread']);
   });
   it('should allow for an array of full EntityTypes descriptions', () => {
-    api.internalActions.invalidateEntities([{ type: 'Banana' }, { type: 'Bread', id: 1 }]);
+    api.util.invalidateEntities([{ type: 'Banana' }, { type: 'Bread', id: 1 }]);
   });
 
   it('should allow for a mix of full descriptions as well as plain strings', () => {
-    api.internalActions.invalidateEntities(['Banana', { type: 'Bread', id: 1 }]);
+    api.util.invalidateEntities(['Banana', { type: 'Bread', id: 1 }]);
   });
   it('should error when using non-existing EntityTypes', () => {
     // @ts-expect-error
-    api.internalActions.invalidateEntities(['Missing Entity']);
+    api.util.invalidateEntities(['Missing Entity']);
   });
   it('should error when using non-existing EntityTypes in the full format', () => {
     // @ts-expect-error
-    api.internalActions.invalidateEntities([{ type: 'Missing' }]);
+    api.util.invalidateEntities([{ type: 'Missing' }]);
   });
 });

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -42,6 +42,32 @@ export const hookWaitFor = async (cb: () => void, time = 2000) => {
   }
 };
 
+export function matchSequence(_actions: AnyAction[], ...matchers: Array<(arg: any) => boolean>) {
+  const actions = _actions.concat();
+  actions.shift(); // remove INIT
+  expect(matchers.length).toBe(actions.length);
+  for (let i = 0; i < matchers.length; i++) {
+    expect(matchers[i](actions[i])).toBe(true);
+  }
+}
+
+export function notMatchSequence(_actions: AnyAction[], ...matchers: Array<Array<(arg: any) => boolean>>) {
+  const actions = _actions.concat();
+  actions.shift(); // remove INIT
+  expect(matchers.length).toBe(actions.length);
+  for (let i = 0; i < matchers.length; i++) {
+    for (const matcher of matchers[i]) {
+      expect(matcher(actions[i])).not.toBe(true);
+    }
+  }
+}
+
+export const actionsReducer = {
+  actions: (state: AnyAction[] = [], action: AnyAction) => {
+    return [...state, action];
+  },
+};
+
 export function setupApiStore<
   A extends { reducerPath: any; reducer: Reducer<any, any>; middleware: Middleware<any> },
   R extends Record<string, Reducer<any, any>>

--- a/test/matchers.test.tsx
+++ b/test/matchers.test.tsx
@@ -1,7 +1,14 @@
-import { AnyAction, createSlice, SerializedError } from '@reduxjs/toolkit';
+import { createSlice, SerializedError } from '@reduxjs/toolkit';
 import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query/react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { expectExactType, hookWaitFor, setupApiStore } from './helpers';
+import {
+  actionsReducer,
+  expectExactType,
+  hookWaitFor,
+  matchSequence,
+  notMatchSequence,
+  setupApiStore,
+} from './helpers';
 
 interface ResultType {
   result: 'complex';
@@ -28,30 +35,8 @@ const api = createApi({
 });
 
 const storeRef = setupApiStore(api, {
-  actions(state: AnyAction[] = [], action: AnyAction) {
-    return [...state, action];
-  },
+  ...actionsReducer,
 });
-
-function matchSequence(_actions: AnyAction[], ...matchers: Array<(arg: any) => boolean>) {
-  const actions = _actions.concat();
-  actions.shift(); // remove INIT
-  expect(matchers.length).toBe(actions.length);
-  for (let i = 0; i < matchers.length; i++) {
-    expect(matchers[i](actions[i])).toBe(true);
-  }
-}
-
-function notMatchSequence(_actions: AnyAction[], ...matchers: Array<Array<(arg: any) => boolean>>) {
-  const actions = _actions.concat();
-  actions.shift(); // remove INIT
-  expect(matchers.length).toBe(actions.length);
-  for (let i = 0; i < matchers.length; i++) {
-    for (const matcher of matchers[i]) {
-      expect(matcher(actions[i])).not.toBe(true);
-    }
-  }
-}
 
 const { mutationFail, mutationSuccess, mutationSuccess2, queryFail, querySuccess, querySuccess2 } = api.endpoints;
 

--- a/test/optimisticUpdates.test.tsx
+++ b/test/optimisticUpdates.test.tsx
@@ -1,7 +1,6 @@
-import { AnyAction } from '@reduxjs/toolkit';
 import { createApi } from '@rtk-incubator/rtk-query/react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { hookWaitFor, setupApiStore, waitMs } from './helpers';
+import { actionsReducer, hookWaitFor, setupApiStore, waitMs } from './helpers';
 import { Patch } from 'immer';
 
 interface Post {
@@ -40,9 +39,7 @@ const api = createApi({
 });
 
 const storeRef = setupApiStore(api, {
-  actions(state: AnyAction[] = [], action: AnyAction) {
-    return [...state, action];
-  },
+  ...actionsReducer,
 });
 
 describe('basic lifecycle', () => {


### PR DESCRIPTION
This needs some help regarding the types because they're currently a :potato:.

Allows a user to invalidate entities at any point without firing off a mutation or calling refetch on a specific endpoint. Supports `['Entity', { type: 'OtherEntity' }, { type: 'EntityWithId', id: 1 }]`

I also thought it'd be cool if we could do a `const invalidate = useInvalidateEntities();`, but I'm not sure of how to get the `EntityTypes` there without some magic.