### PR TITLE
Miscellaneous documentation work

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,15 @@
 {
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "printWidth": 120,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.ts",
+      "options": {
+        "parser": "babel-ts"
+      }
+    }
+  ]
 }

--- a/docs/api/ApiProvider.md
+++ b/docs/api/ApiProvider.md
@@ -7,20 +7,9 @@ hide_title: true
 
 # `ApiProvider`
 
-Can be used as a `Provider` if you **do not already have a Redux store**.
+[summary](docblock://react-hooks/ApiProvider.tsx?token=ApiProvider)
 
-```ts title="Basic usage - wrap your App with ApiProvider"
-import * as React from 'react';
-import { ApiProvider } from '@rtk-incubator/rtk-query';
-
-function App() {
-  return (
-    <ApiProvider api={api}>
-      <Pokemon />
-    </ApiProvider>
-  );
-}
-```
+[examples](docblock://react-hooks/ApiProvider.tsx?token=ApiProvider)
 
 :::danger
 Using this together with an existing redux store will cause them to conflict with each other. If you are already using Redux, please use follow the instructions as shown in the [Getting Started guide](../introduction/getting-started).

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -26,16 +26,17 @@ The main point where you will define a service to use in your application.
 ```
 
 ### `baseQuery`
-The base query used by each endpoint if no `queryFn` option is specified. RTK Query exports a utility called [fetchBaseQuery](./fetchBaseQuery) as a lightweight wrapper around `fetch` for common use-cases.
+
+[summary](docblock://createApi.ts?token=CreateApiOptions.baseQuery)
 
 ```ts title="Simulating axios-like interceptors with a custom base query"
 const baseQuery = fetchBaseQuery({ baseUrl: '/' });
 
-const baseQueryWithReauth: BaseQueryFn<
-  string | FetchArgs,
-  unknown,
-  FetchBaseQueryError
-> = async (args, api, extraOptions) => {
+const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
+  args,
+  api,
+  extraOptions
+) => {
   let result = await baseQuery(args, api, extraOptions);
   if (result.error && result.error.status === '401') {
     // try to get a new token
@@ -50,16 +51,16 @@ const baseQueryWithReauth: BaseQueryFn<
     }
   }
   return result;
-}
+};
 ```
 
 ### `entityTypes`
 
-An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation. When defining an entity type, you will be able to [provide](../concepts/mutations#provides) them with `provides` and [invalidate](../concepts/mutations#advanced-mutations-with-revalidation) them with `invalidates` when configuring [endpoints](#endpoints).
+[summary](docblock://createApi.ts?token=CreateApiOptions.entityTypes)
 
 ### `reducerPath`
 
-The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
+[summary](docblock://createApi.ts?token=CreateApiOptions.reducerPath)
 
 ```js title="apis.js"
 import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
@@ -83,7 +84,8 @@ const apiTwo = createApi({
 
 ### `serializeQueryArgs`
 
-Accepts a custom function if you have a need to change the creation of cache keys for any reason. Defaults to:
+[summary](docblock://createApi.ts?token=CreateApiOptions.reducerPath)
+Defaults to:
 
 ```ts no-compile
 export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpoint, queryArgs }) => {
@@ -94,15 +96,15 @@ export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpoint, q
 
 ### `endpoints`
 
-Endpoints are just a set of operations that you want to perform against your server. You define them as an object using the builder syntax. There are two basic endpoint types: [`query`](../concepts/queries) and [`mutation`](../concepts/mutations).
+[summary](docblock://createApi.ts?token=CreateApiOptions.endpoints)
 
 #### Anatomy of an endpoint
 
 - `query` _(required)_
-  - `query` is the only required property, and can be a function that returns either a `string` or an `object` which is passed to your `baseQuery`. If you are using [fetchBaseQuery](./fetchBaseQuery), this can return either a `string` or an `object` of properties in `FetchArgs`. If you use your own custom `baseQuery`, you can customize this behavior to your liking
+  - [summary](docblock://endpointDefinitions.ts?token=EndpointDefinitionWithQuery.query)
 - `transformResponse` _(optional)_
 
-  - A function to manipulate the data returned by a query or mutation
+  - [summary](docblock://endpointDefinitions.ts?token=EndpointDefinitionWithQuery.transformResponse)
   - ```js title="Unpack a deeply nested collection"
     transformResponse: (response) => response.some.nested.collection;
     ```
@@ -115,15 +117,12 @@ Endpoints are just a set of operations that you want to perform against your ser
     ```
 
 - `provides` _(optional)_
-  - Used by `queries` to provide entities to the cache
-  - Expects an array of entity type strings, or an array of objects of entity types with ids.
-    1.  `['Post']` - equivalent to `b`
-    2.  `[{ type: 'Post' }]` - equivalent to `a`
-    3.  `[{ type: 'Post', id: 1 }]`
+
+  [summary](docblock://endpointDefinitions.ts?token=QueryExtraOptions.provides)
+
 - `invalidates` _(optional)_
 
-  - Used by `mutations` for [cache invalidation](../concepts/mutations#advanced-mutations-with-revalidation) purposes.
-  - Expects the same shapes as `provides`
+  [summary](docblock://endpointDefinitions.ts?token=MutationExtraOptions.invalidates)
 
 - `onStart`, `onError` and `onSuccess` _(optional)_ - Available to both [queries](../concepts/queries) and [mutations](../concepts/mutations)
   - Can be used in `mutations` for [optimistic updates](../concepts/optimistic-updates).

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -26,6 +26,7 @@ The main point where you will define a service to use in your application.
 ```
 
 ### `baseQuery`
+The base query used by each endpoint if no `queryFn` option is specified. RTK Query exports a utility called [fetchBaseQuery](./fetchBaseQuery) as a lightweight wrapper around `fetch` for common use-cases.
 
 ```ts title="Simulating axios-like interceptors with a custom base query"
 const baseQuery = fetchBaseQuery({ baseUrl: '/' });
@@ -54,7 +55,7 @@ const baseQueryWithReauth: BaseQueryFn<
 
 ### `entityTypes`
 
-Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation. When defining an entity type, you will be able to add them with `provides` and [invalidate](../concepts/mutations#advanced-mutations-with-revalidation) them with `invalidates` when configuring [endpoints](#endpoints).
+An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation. When defining an entity type, you will be able to [provide](../concepts/mutations#provides) them with `provides` and [invalidate](../concepts/mutations#advanced-mutations-with-revalidation) them with `invalidates` when configuring [endpoints](#endpoints).
 
 ### `reducerPath`
 
@@ -86,7 +87,7 @@ Accepts a custom function if you have a need to change the creation of cache key
 
 ```ts no-compile
 export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpoint, queryArgs }) => {
-  // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than  useQuery({ b: 2, a: 1 })
+  // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
   return `${endpoint}(${JSON.stringify(queryArgs, Object.keys(queryArgs || {}).sort())})`;
 };
 ```
@@ -98,14 +99,14 @@ Endpoints are just a set of operations that you want to perform against your ser
 #### Anatomy of an endpoint
 
 - `query` _(required)_
-  - `query` is the only required property, and can be either a `string` or an `object` that is passed to your `baseQuery`. If you are using [fetchBaseQuery](./fetchBaseQuery), this can be a `string` or an object of properties in `FetchArgs`. If you use your own custom `baseQuery`, you can customize this behavior to your liking
+  - `query` is the only required property, and can be a function that returns either a `string` or an `object` which is passed to your `baseQuery`. If you are using [fetchBaseQuery](./fetchBaseQuery), this can return either a `string` or an `object` of properties in `FetchArgs`. If you use your own custom `baseQuery`, you can customize this behavior to your liking
 - `transformResponse` _(optional)_
 
   - A function to manipulate the data returned by a query or mutation
   - ```js title="Unpack a deeply nested collection"
     transformResponse: (response) => response.some.nested.collection;
     ```
-    ```js title="Normalize the response data"
+  - ```js title="Normalize the response data"
     transformResponse: (response) =>
       response.reduce((acc, curr) => {
         acc[curr.id] = curr;
@@ -116,8 +117,8 @@ Endpoints are just a set of operations that you want to perform against your ser
 - `provides` _(optional)_
   - Used by `queries` to provide entities to the cache
   - Expects an array of entity type strings, or an array of objects of entity types with ids.
-    1.  `['Post']` - equivalent to 2
-    2.  `[{ type: 'Post' }]` - equivalent to 1
+    1.  `['Post']` - equivalent to `b`
+    2.  `[{ type: 'Post' }]` - equivalent to `a`
     3.  `[{ type: 'Post', id: 1 }]`
 - `invalidates` _(optional)_
 
@@ -290,6 +291,7 @@ export const {
   internalActions,
   util,
   injectEndpoints,
+  enhanceEndpoints,
   usePrefetch,
   ...generatedHooks
 } = api;

--- a/docs/api/fetchBaseQuery.md
+++ b/docs/api/fetchBaseQuery.md
@@ -52,13 +52,12 @@ export const pokemonApi = createApi({
       query: (name: string) => `pokemon/${name}`, // Will make a request like https://pokeapi.co/api/v2/bulbasaur
     }),
     updatePokemon: builder.mutation({
-        query: ({ name, patch }) => ({
-          url: `pokemon/${name}`,
-          method: 'PATCH', // When performing a mutation, you typically use a method of PATCH/PUT/POST/DELETE for REST endpoints
-          body: patch, // fetchBaseQuery automatically adds `content-type: application/json` to the Headers and calls `JSON.stringify(patch)`
-        })
-      },
-    })
+      query: ({ name, patch }) => ({
+        url: `pokemon/${name}`,
+        method: 'PATCH', // When performing a mutation, you typically use a method of PATCH/PUT/POST/DELETE for REST endpoints
+        body: patch, // fetchBaseQuery automatically adds `content-type: application/json` to the Headers and calls `JSON.stringify(patch)`
+      }),
+    }),
   }),
 });
 ```

--- a/docs/api/setupListeners.md
+++ b/docs/api/setupListeners.md
@@ -63,8 +63,8 @@ export function setupListeners(
 }
 ```
 
-If you notice, `onFocus`, `onFocusLost`, `onOffline`, `onOnline` are all actions that are provided to the callback. Additionally, these action are made available to `api.internalActions` and are able to be used by dispatching them like this:
+If you notice, `onFocus`, `onFocusLost`, `onOffline`, `onOnline` are all actions that are provided to the callback. Additionally, these actions are made available to `api.internalActions` and are able to be used by dispatching them like this:
 
 ```ts title="Manual onFocus event"
-dispatch(api.internalActions.onFocus())`
+dispatch(api.internalActions.onFocus());
 ```

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -116,31 +116,9 @@ RTK Query exports a utility called `retry` that you can wrap the `baseQuery` in 
 
 The default behavior would retry at these intervals:
 
-1. 600ms + random time
-2. 1200ms + random time
-3. 2400ms + random time
-4. 4800ms + random time
-5. 9600ms + random time
+[remarks](docblock://retry.ts?token=defaultBackoff)
 
-```ts title="Retry every request 5 times by default"
-// maxRetries: 5 is the default, and can be omitted. Shown for documentation purposes.
-const staggeredBaseQuery = retry(fetchBaseQuery({ baseUrl: '/' }), { maxRetries: 5 });
-
-export const api = createApi({
-  baseQuery: staggeredBaseQuery,
-  endpoints: (build) => ({
-    getPosts: build.query<PostsResponse, void>({
-      query: () => ({ url: 'posts' }),
-    }),
-    getPost: build.query<PostsResponse, void>({
-      query: (id: string) => ({ url: `posts/${id}` }),
-      extraOptions: { maxRetries: 8 }, // You can override the retry behavior on each endpoint
-    }),
-  }),
-});
-
-export const { useGetPostsQuery, useGetPostQuery } = api;
-```
+[examples](docblock://retry.ts?token=retry)
 
 In the event that you didn't want to retry on a specific endpoint, you can just set `maxRetries: 0`.
 

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -39,26 +39,36 @@ Notice the `onStart`, `onSuccess`, `onError` methods? Be sure to check out how t
 ### Type interfaces
 
 ```ts title="Mutation endpoint definition"
-export interface MutationDefinition<
+export type MutationDefinition<
   QueryArg,
-  BaseQuery extends (arg: any, ...args: any[]) => any,
+  BaseQuery extends BaseQueryFn,
   EntityTypes extends string,
   ResultType,
   ReducerPath extends string = string,
   Context = Record<string, any>
-> extends BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> {
+> = BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> & {
   type: DefinitionType.mutation;
   invalidates?: ResultDescription<EntityTypes, ResultType, QueryArg>;
   provides?: never;
   onStart?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>): void;
-  onError?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>, error: unknown): void;
-  onSuccess?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>, result: ResultType): void;
-}
+  onError?(
+    arg: QueryArg,
+    mutationApi: MutationApi<ReducerPath, Context>,
+    error: unknown,
+    meta: BaseQueryMeta<BaseQuery>
+  ): void;
+  onSuccess?(
+    arg: QueryArg,
+    mutationApi: MutationApi<ReducerPath, Context>,
+    result: ResultType,
+    meta: BaseQueryMeta<BaseQuery> | undefined
+  ): void;
+};
 ```
 
 ```ts title="MutationApi"
 export interface MutationApi<ReducerPath extends string, Context extends {}> {
-  dispatch: ThunkDispatch<RootState<any, any, ReducerPath>, unknown, AnyAction>;
+  dispatch: ThunkDispatch<any, any, AnyAction>;
   getState(): RootState<any, any, ReducerPath>;
   extra: unknown;
   requestId: string;

--- a/docs/concepts/prefetching.md
+++ b/docs/concepts/prefetching.md
@@ -39,13 +39,8 @@ usePrefetch<EndpointName extends QueryKeys<Definitions>>(
 
 You can specify these prefetch options when declaring the hook or at the call site. The call site will take priority over the defaults.
 
-1. `ifOlderThan` - (default: `false` | `number`) - _number is value in seconds_
-
-   - If specified, it will only run the query if the difference between `new Date()` and the last `fulfilledTimeStamp` is greater than the given value
-
-2. `force`
-
-   - If `force: true`, it will ignore the `ifOlderThan` value if it is set and the query will be run even if it exists in the cache.
+1. [summary](docblock://core/module.ts?token=PrefetchOptions)
+2. [overloadSummary](docblock://core/module.ts?token=PrefetchOptions)
 
 #### What to expect when you call the `callback`
 

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -115,7 +115,7 @@ The way that this component is setup would have some nice traits:
 
 ### Selecting data from a query result
 
-Sometimes you may have a parent component that is subscribed to a query, and then in a child component you want to pick an item from that query. In most cases you don't want to perform an additional request for a `getItemById`-type query when you know that you already have the result. `selectFromResult` allows you to get a specific segment from a query result in a performant manner. When using this feature, the component will not rerender unless the underlying data of the selected item has changed. If the selected item is one elemnt in a larger collection, it will disregard changes to elements in the same collection.
+Sometimes you may have a parent component that is subscribed to a query, and then in a child component you want to pick an item from that query. In most cases you don't want to perform an additional request for a `getItemById`-type query when you know that you already have the result. `selectFromResult` allows you to get a specific segment from a query result in a performant manner. When using this feature, the component will not rerender unless the underlying data of the selected item has changed. If the selected item is one element in a larger collection, it will disregard changes to elements in the same collection.
 
 ```ts title="Using selectFromResult to extract a single result"
 function PostsList() {

--- a/package.json
+++ b/package.json
@@ -47,20 +47,6 @@
       "pre-commit": "tsdx lint"
     }
   },
-  "prettier": {
-    "printWidth": 120,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "overrides": [
-      {
-        "files": "*.ts",
-        "options": {
-          "parser": "babel-ts"
-        }
-      }
-    ]
-  },
   "size-limit": [
     {
       "name": "ESM full",

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -46,10 +46,16 @@ export type Api<
   Enhancers extends ModuleName = CoreModule
 > = Id<
   Id<UnionToIntersection<ApiModules<BaseQuery, Definitions, ReducerPath, EntityTypes>[Enhancers]>> & {
+    /**
+     * A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
+     */
     injectEndpoints<NewDefinitions extends EndpointDefinitions>(_: {
       endpoints: (build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>) => NewDefinitions;
       overrideExisting?: boolean;
     }): Api<BaseQuery, Definitions & NewDefinitions, ReducerPath, EntityTypes, Enhancers>;
+    /**
+     *A function to enhance a generated API with additional information. Useful with code-generation.
+     */
     enhanceEndpoints<NewEntityTypes extends string = never>(_: {
       addEntityTypes?: readonly NewEntityTypes[];
       endpoints?: ReplaceEntityTypes<Definitions, EntityTypes | NoInfer<NewEntityTypes>> extends infer NewDefinitions

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -20,6 +20,9 @@ export type RefetchConfigOptions = {
   refetchOnFocus: boolean;
 };
 
+/**
+ * Strings describing the query state at any given time.
+ */
 export enum QueryStatus {
   uninitialized = 'uninitialized',
   pending = 'pending',

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,49 +1,6 @@
 import { buildCreateApi } from '../createApi';
 import { coreModule } from './module';
 
-/**
- * Creates a service to use in your application. Contains only the basic redux logic (the core module).
- *
- * @link https://rtk-query-docs.netlify.app/api/createApi
- *
- * @param opts.baseQuery
- * The base query used by each endpoint if no `queryFn` option is specified.
- * @param opts.entityTypes
- * An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation.
- * @param opts.reducerPath
- * The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
- * @param opts.serializeQueryArgs
- * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
- * @param opts.endpoints
- * A set of operations to perform against your server defined as an object using the builder syntax.
- * @param opts.keepUnusedDataFor
- * Defaults to 60 (this value is in seconds). This is how long RTK Query will keep your data cached for after the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
- * @param opts.refetchOnMountOrArgChange
- * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
- * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
- * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
- * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- * @param opts.refetchOnFocus
- * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- * @param opts.refetchOnReconnect
- * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- *
- * @returns Object containing the following:
- * - `reducerPath`
- * - `reducer` - A standard redux reducer that enables core functionality. Make sure it's included in your store.
- * - `middleware` - This is a standard redux middleware and is responsible for things like polling, garbage collection and a handful of other things. Make sure it's included in your store.
- * - `endpoints` - Endpoints based on the input endpoints provided to `createApi`, containing `select` and `action matchers`.
- * - `internalActions` - Internal actions not part of the public API. Note: These are subject to change at any given time.
- * - `util` - `prefetchThunk`, `patchQueryResult`, `updateQueryResult`
- * - `injectEndpoints` - A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
- * - `enhanceEndpoints` - A function to enhance a generated API with additional information. Useful with code-generation.
- */
 const createApi = buildCreateApi(coreModule());
 
 export { createApi, coreModule };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,49 @@
 import { buildCreateApi } from '../createApi';
 import { coreModule } from './module';
 
+/**
+ * Creates a service to use in your application. Contains only the basic redux logic (the core module).
+ *
+ * @link https://rtk-query-docs.netlify.app/api/createApi
+ *
+ * @param opts.baseQuery
+ * The base query used by each endpoint if no `queryFn` option is specified.
+ * @param opts.entityTypes
+ * An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation.
+ * @param opts.reducerPath
+ * The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
+ * @param opts.serializeQueryArgs
+ * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
+ * @param opts.endpoints
+ * A set of operations to perform against your server defined as an object using the builder syntax.
+ * @param opts.keepUnusedDataFor
+ * Defaults to 60 (this value is in seconds). This is how long RTK Query will keep your data cached for after the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
+ * @param opts.refetchOnMountOrArgChange
+ * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
+ * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
+ * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
+ * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ * @param opts.refetchOnFocus
+ * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ * @param opts.refetchOnReconnect
+ * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ *
+ * @returns Object containing the following:
+ * - `reducerPath`
+ * - `reducer` - A standard redux reducer that enables core functionality. Make sure it's included in your store.
+ * - `middleware` - This is a standard redux middleware and is responsible for things like polling, garbage collection and a handful of other things. Make sure it's included in your store.
+ * - `endpoints` - Endpoints based on the input endpoints provided to `createApi`, containing `select` and `action matchers`.
+ * - `internalActions` - Internal actions not part of the public API. Note: These are subject to change at any given time.
+ * - `util` - `prefetchThunk`, `patchQueryResult`, `updateQueryResult`
+ * - `injectEndpoints` - A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
+ * - `enhanceEndpoints` - A function to enhance a generated API with additional information. Useful with code-generation.
+ */
 const createApi = buildCreateApi(coreModule());
 
 export { createApi, coreModule };

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -52,26 +52,84 @@ declare module '../apiTypes' {
     EntityTypes extends string
   > {
     [coreModuleName]: {
+      /**
+       * This api's reducer should be mounted at `store[api.reducerPath]`.
+       *
+       * @example
+       * ```ts
+       * configureStore({
+       *   reducer: {
+       *     [api.reducerPath]: api.reducer,
+       *   },
+       *   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+       * })
+       * ```
+       */
       reducerPath: ReducerPath;
+      /**
+       * Internal actions not part of the public API. Note: These are subject to change at any given time.
+       */
       internalActions: InternalActions;
+      /**
+       *  A standard redux reducer that enables core functionality. Make sure it's included in your store.
+       *
+       * @example
+       * ```ts
+       * configureStore({
+       *   reducer: {
+       *     [api.reducerPath]: api.reducer,
+       *   },
+       *   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+       * })
+       * ```
+       */
       reducer: Reducer<CombinedState<Definitions, EntityTypes, ReducerPath>, AnyAction>;
+      /**
+       * This is a standard redux middleware and is responsible for things like polling, garbage collection and a handful of other things. Make sure it's included in your store.
+       *
+       * @example
+       * ```ts
+       * configureStore({
+       *   reducer: {
+       *     [api.reducerPath]: api.reducer,
+       *   },
+       *   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+       * })
+       * ```
+       */
       middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>>;
+      /**
+       * TODO
+       */
       util: {
+        /**
+         * TODO
+         */
         prefetchThunk<EndpointName extends QueryKeys<EndpointDefinitions>>(
           endpointName: EndpointName,
           arg: QueryArgFrom<Definitions[EndpointName]>,
           options: PrefetchOptions
         ): ThunkAction<void, any, any, AnyAction>;
+        /**
+         * TODO
+         */
         updateQueryResult: UpdateQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+        /**
+         * TODO
+         */
         patchQueryResult: PatchQueryResultThunk<Definitions, RootState<Definitions, string, ReducerPath>>;
+        /**
+         * TODO
+         */
         resetApiState: SliceActions['resetApiState'];
+        /**
+         * TODO
+         */
         invalidateEntities: ActionCreatorWithPayload<Array<EntityTypes | FullEntityDescription<EntityTypes>>, string>;
       };
-      // If you actually care about the return value, use useQuery
-      usePrefetch<EndpointName extends QueryKeys<Definitions>>(
-        endpointName: EndpointName,
-        options?: PrefetchOptions
-      ): (arg: QueryArgFrom<Definitions[EndpointName]>, options?: PrefetchOptions) => void;
+      /**
+       * Endpoints based on the input endpoints provided to `createApi`, containing `select` and `action matchers`.
+       */
       endpoints: {
         [K in keyof Definitions]: Definitions[K] extends QueryDefinition<any, any, any, any, any>
           ? Id<ApiEndpointQuery<Definitions[K], Definitions>>

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -26,11 +26,19 @@ import { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs';
 import { SliceActions } from './buildSlice';
 import { BaseQueryFn } from '../baseQueryTypes';
 
+/**
+ * `ifOlderThan` - (default: `false` | `number`) - _number is value in seconds_
+ * - If specified, it will only run the query if the difference between `new Date()` and the last `fulfilledTimeStamp` is greater than the given value
+ *
+ * @overloadSummary
+ * `force`
+ * - If `force: true`, it will ignore the `ifOlderThan` value if it is set and the query will be run even if it exists in the cache.
+ */
 export type PrefetchOptions =
-  | { force?: boolean }
   | {
       ifOlderThan?: false | number;
-    };
+    }
+  | { force?: boolean };
 
 export const coreModuleName = Symbol();
 export type CoreModule = typeof coreModuleName;
@@ -107,6 +115,14 @@ export type ListenerActions = {
 
 export type InternalActions = SliceActions & ListenerActions;
 
+/**
+ * Creates a module containing the basic redux logic for use with `buildCreateApi`.
+ *
+ * @example
+ * ```ts
+ * const createBaseApi = buildCreateApi(coreModule());
+ * ```
+ */
 export const coreModule = (): Module<CoreModule> => ({
   name: coreModuleName,
   init(

--- a/src/core/setupListeners.ts
+++ b/src/core/setupListeners.ts
@@ -6,6 +6,23 @@ export const onOnline = createAction('__rtkq/online');
 export const onOffline = createAction('__rtkq/offline');
 
 let initialized = false;
+
+/**
+ * A utility used to enable `refetchOnMount` and `refetchOnReconnect` behaviors.
+ * It requires the dispatch method from your store.
+ * Calling `setupListeners(store.dispatch)` will configure listeners with the recommended defaults,
+ * but you have the option of providing a callback for more granular control.
+ *
+ * @example
+ * ```ts
+ * setupListeners(store.dispatch)
+ * ```
+ *
+ * @param dispatch - The dispatch method from your store
+ * @param customHandler - An optional callback for more granular control over listener behavior
+ * @returns Return value of the handler.
+ * The default handler returns an `unsubscribe` method that can be called to remove the listeners.
+ */
 export function setupListeners(
   dispatch: ThunkDispatch<any, any, any>,
   customHandler?: (

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -29,6 +29,23 @@ export type CreateApi<Modules extends ModuleName> = <
   options: CreateApiOptions<BaseQuery, Definitions, ReducerPath, EntityTypes>
 ) => Api<BaseQuery, Definitions, ReducerPath, EntityTypes, Modules>;
 
+/**
+ * Builds a `createApi` method based on the provided `modules`.
+ *
+ * @link https://rtk-query-docs.netlify.app/concepts/customizing-create-api
+ *
+ * @example
+ * ```ts
+ * const MyContext = React.createContext<ReactReduxContextValue>(null as any);
+ * const customCreateApi = buildCreateApi(
+ *   coreModule(),
+ *   reactHooksModule({ useDispatch: createDispatchHook(MyContext) })
+ * );
+ * ```
+ *
+ * @param modules - A variable number of modules that customize how the `createApi` method handles endpoints
+ * @returns A `createApi` method using the provided `modules`.
+ */
 export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
   ...modules: Modules
 ): CreateApi<Modules[number]['name']> {

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -9,25 +9,68 @@ export interface CreateApiOptions<
   ReducerPath extends string = 'api',
   EntityTypes extends string = never
 > {
+  /**
+   * The base query used by each endpoint if no `queryFn` option is specified. RTK Query exports a utility called [fetchBaseQuery](./fetchBaseQuery) as a lightweight wrapper around `fetch` for common use-cases.
+   */
   baseQuery: BaseQuery;
+  /**
+   * An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation. When defining an entity type, you will be able to [provide](../concepts/mutations#provides) them with `provides` and [invalidate](../concepts/mutations#advanced-mutations-with-revalidation) them with `invalidates` when configuring [endpoints](#endpoints).
+   */
   entityTypes?: readonly EntityTypes[];
+  /**
+   * The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
+   */
   reducerPath?: ReducerPath;
+  /**
+   * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
+   */
   serializeQueryArgs?: SerializeQueryArgs<BaseQueryArg<BaseQuery>>;
+  /**
+   * Endpoints are just a set of operations that you want to perform against your server. You define them as an object using the builder syntax. There are two basic endpoint types: [`query`](../concepts/queries) and [`mutation`](../concepts/mutations).
+   */
   endpoints(build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>): Definitions;
+  /**
+   * Defaults to 60 (this value is in seconds). This is how long RTK Query will keep your data cached for after the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
+   */
   keepUnusedDataFor?: number;
+  /**
+   * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
+   * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
+   * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
+   * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
+   *
+   * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   */
   refetchOnMountOrArgChange?: boolean | number;
+  /**
+   * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
+   *
+   * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   */
   refetchOnFocus?: boolean;
+  /**
+   * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
+   *
+   * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   */
   refetchOnReconnect?: boolean;
 }
 
-export type CreateApi<Modules extends ModuleName> = <
-  BaseQuery extends BaseQueryFn,
-  Definitions extends EndpointDefinitions,
-  ReducerPath extends string = 'api',
-  EntityTypes extends string = never
->(
-  options: CreateApiOptions<BaseQuery, Definitions, ReducerPath, EntityTypes>
-) => Api<BaseQuery, Definitions, ReducerPath, EntityTypes, Modules>;
+export type CreateApi<Modules extends ModuleName> = {
+  /**
+   * Creates a service to use in your application. Contains only the basic redux logic (the core module).
+   *
+   * @link https://rtk-query-docs.netlify.app/api/createApi
+   */
+  <
+    BaseQuery extends BaseQueryFn,
+    Definitions extends EndpointDefinitions,
+    ReducerPath extends string = 'api',
+    EntityTypes extends string = never
+  >(
+    options: CreateApiOptions<BaseQuery, Definitions, ReducerPath, EntityTypes>
+  ): Api<BaseQuery, Definitions, ReducerPath, EntityTypes, Modules>;
+};
 
 /**
  * Builds a `createApi` method based on the provided `modules`.

--- a/src/defaultSerializeQueryArgs.ts
+++ b/src/defaultSerializeQueryArgs.ts
@@ -2,7 +2,7 @@ import { QueryCacheKey } from './core/apiState';
 import { EndpointDefinition } from './endpointDefinitions';
 
 export const defaultSerializeQueryArgs: SerializeQueryArgs<any> = ({ endpointName, queryArgs }) => {
-  // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than  useQuery({ b: 2, a: 1 })
+  // Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
   return `${endpointName}(${JSON.stringify(queryArgs, Object.keys(queryArgs || {}).sort())})`;
 };
 

--- a/src/fetchBaseQuery.ts
+++ b/src/fetchBaseQuery.ts
@@ -64,6 +64,21 @@ export type FetchBaseQueryMeta = { request: Request; response: Response };
 /**
  * This is a very small wrapper around fetch that aims to simplify requests.
  *
+ * @example
+ * ```ts
+ * const baseQuery = fetchBaseQuery({
+ *   baseUrl: 'https://api.your-really-great-app.com/v1/',
+ *   prepareHeaders: (headers, { getState }) => {
+ *     const token = (getState() as RootState).auth.token;
+ *     // If we have a token set in state, let's assume that we should be passing it.
+ *     if (token) {
+ *       headers.set('authorization', `Bearer ${token}`);
+ *     }
+ *     return headers;
+ *   },
+ * })
+ * ```
+ *
  * @param {string} baseUrl
  * The base URL for an API service.
  * Typically in the format of http://example.com/

--- a/src/react-hooks/ApiProvider.tsx
+++ b/src/react-hooks/ApiProvider.tsx
@@ -5,7 +5,23 @@ import { setupListeners } from '../core/setupListeners';
 import { Api } from '../apiTypes';
 
 /**
- * Can be used as a Provider if you **do not have a Redux store**.
+ * Can be used as a `Provider` if you **do not already have a Redux store**.
+ *
+ * @example
+ * ```ts title="Basic usage - wrap your App with ApiProvider"
+ * import * as React from 'react';
+ * import { ApiProvider } from '@rtk-incubator/rtk-query';
+ *
+ * function App() {
+ *   return (
+ *     <ApiProvider api={api}>
+ *       <Pokemon />
+ *     </ApiProvider>
+ *   );
+ * }
+ * ```
+ *
+ * @remarks
  * Using this together with an existing redux store, both will
  * conflict with each other - please use the traditional redux setup
  * in that case.

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -177,6 +177,14 @@ type GenericPrefetchThunk = (
   options: PrefetchOptions
 ) => ThunkAction<void, any, any, AnyAction>;
 
+/**
+ *
+ * @param opts.api - An API with defined endpoints to create hooks for
+ * @param opts.moduleOptions.batch - The version of the `batchedUpdates` function to be used
+ * @param opts.moduleOptions.useDispatch - The version of the `useDispatch` hook to be used
+ * @param opts.moduleOptions.useSelector - The version of the `useSelector` hook to be used
+ * @returns An object containing functions to generate hooks based on an endpoint
+ */
 export function buildHooks<Definitions extends EndpointDefinitions>({
   api,
   moduleOptions: { batch, useDispatch, useSelector },

--- a/src/react-hooks/index.ts
+++ b/src/react-hooks/index.ts
@@ -2,51 +2,6 @@ import { coreModule } from '../core/module';
 import { buildCreateApi } from '../createApi';
 import { reactHooksModule } from './module';
 
-/**
- * Creates a service to use in your application. Contains both the core and react-hooks modules.
- *
- * @link https://rtk-query-docs.netlify.app/api/createApi
- *
- * @param opts.baseQuery
- * The base query used by each endpoint if no `queryFn` option is specified.
- * @param opts.entityTypes
- * An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation.
- * @param opts.reducerPath
- * The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
- * @param opts.serializeQueryArgs
- * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
- * @param opts.endpoints
- * A set of operations to perform against your server defined as an object using the builder syntax.
- * @param opts.keepUnusedDataFor
- * Defaults to 60 (this value is in seconds). This is how long RTK Query will keep your data cached for after the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
- * @param opts.refetchOnMountOrArgChange
- * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
- * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
- * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
- * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- * @param opts.refetchOnFocus
- * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- * @param opts.refetchOnReconnect
- * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
- *
- * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
- *
- * @returns Object containing the following:
- * - `reducerPath`
- * - `reducer` - A standard redux reducer that enables core functionality. Make sure it's included in your store.
- * - `middleware` - This is a standard redux middleware and is responsible for things like polling, garbage collection and a handful of other things. Make sure it's included in your store.
- * - `endpoints` - Endpoints based on the input endpoints provided to `createApi`, containing `select`, `hooks` and `action matchers`.
- * - `internalActions` - Internal actions not part of the public API. Note: These are subject to change at any given time.
- * - `util` - `prefetchThunk`, `patchQueryResult`, `updateQueryResult`
- * - `injectEndpoints` - A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
- * - `enhanceEndpoints` - A function to enhance a generated API with additional information. Useful with code-generation.
- * - `usePrefetch` - A hook that accepts a string endpoint name, and provides a callback that when called, pre-fetches the data for that endpoint.
- * - `...generatedHooks` - Auto-generated `query` and `mutation` hooks intended to be used as the core method for components to interface with the API.
- */
 const createApi = buildCreateApi(coreModule(), reactHooksModule());
 
 export { createApi, reactHooksModule };

--- a/src/react-hooks/index.ts
+++ b/src/react-hooks/index.ts
@@ -2,6 +2,51 @@ import { coreModule } from '../core/module';
 import { buildCreateApi } from '../createApi';
 import { reactHooksModule } from './module';
 
+/**
+ * Creates a service to use in your application. Contains both the core and react-hooks modules.
+ *
+ * @link https://rtk-query-docs.netlify.app/api/createApi
+ *
+ * @param opts.baseQuery
+ * The base query used by each endpoint if no `queryFn` option is specified.
+ * @param opts.entityTypes
+ * An array of string entity type names. Specifying entity types is optional, but you should define them so that they can be used for caching and invalidation.
+ * @param opts.reducerPath
+ * The `reducerPath` is a _unique_ key that your service will be mounted to in your store. If you call `createApi` more than once in your application, you will need to provide a unique value each time. Defaults to `api`.
+ * @param opts.serializeQueryArgs
+ * Accepts a custom function if you have a need to change the creation of cache keys for any reason.
+ * @param opts.endpoints
+ * A set of operations to perform against your server defined as an object using the builder syntax.
+ * @param opts.keepUnusedDataFor
+ * Defaults to 60 (this value is in seconds). This is how long RTK Query will keep your data cached for after the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
+ * @param opts.refetchOnMountOrArgChange
+ * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
+ * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
+ * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
+ * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ * @param opts.refetchOnFocus
+ * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ * @param opts.refetchOnReconnect
+ * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
+ *
+ * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+ *
+ * @returns Object containing the following:
+ * - `reducerPath`
+ * - `reducer` - A standard redux reducer that enables core functionality. Make sure it's included in your store.
+ * - `middleware` - This is a standard redux middleware and is responsible for things like polling, garbage collection and a handful of other things. Make sure it's included in your store.
+ * - `endpoints` - Endpoints based on the input endpoints provided to `createApi`, containing `select`, `hooks` and `action matchers`.
+ * - `internalActions` - Internal actions not part of the public API. Note: These are subject to change at any given time.
+ * - `util` - `prefetchThunk`, `patchQueryResult`, `updateQueryResult`
+ * - `injectEndpoints` - A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
+ * - `enhanceEndpoints` - A function to enhance a generated API with additional information. Useful with code-generation.
+ * - `usePrefetch` - A hook that accepts a string endpoint name, and provides a callback that when called, pre-fetches the data for that endpoint.
+ * - `...generatedHooks` - Auto-generated `query` and `mutation` hooks intended to be used as the core method for components to interface with the API.
+ */
 const createApi = buildCreateApi(coreModule(), reactHooksModule());
 
 export { createApi, reactHooksModule };

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -53,6 +53,24 @@ export interface ReactHooksModuleOptions {
   useStore?: RR['useStore'];
 }
 
+/**
+ * Creates a module that generates react hooks from endpoints, for use with `buildCreateApi`.
+ *
+ *  @example
+ * ```ts
+ * const MyContext = React.createContext<ReactReduxContextValue>(null as any);
+ * const customCreateApi = buildCreateApi(
+ *   coreModule(),
+ *   reactHooksModule({ useDispatch: createDispatchHook(MyContext) })
+ * );
+ * ```
+ *
+ * @param opts.batch - The version of the `batchedUpdates` function to be used
+ * @param opts.useDispatch - The version of the `useDispatch` hook to be used
+ * @param opts.useSelector - The version of the `useSelector` hook to be used
+ * @param opts.useStore - Currently unused - for potential future use
+ * @returns A module for use with `buildCreateApi`
+ */
 export const reactHooksModule = ({
   batch = rrBatch,
   useDispatch = rrUseDispatch,

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,16 +1,22 @@
 import { BaseQueryEnhancer } from './baseQueryTypes';
 import { HandledError } from './HandledError';
 
+/**
+ * Exponential backoff based on the attempt number.
+ *
+ * @remarks
+ * 1. 600ms * random(0.4, 1.4)
+ * 2. 1200ms * random(0.4, 1.4)
+ * 3. 2400ms * random(0.4, 1.4)
+ * 4. 4800ms * random(0.4, 1.4)
+ * 5. 9600ms * random(0.4, 1.4)
+ *
+ * @param attempt - Current attempt
+ * @param maxRetries - Maximum number of retries
+ */
 async function defaultBackoff(attempt: number = 0, maxRetries: number = 5) {
   const attempts = Math.min(attempt, maxRetries);
-  /**
-   * Exponential backoff that would give a baseline like:
-   * 1 - 600ms + rand
-   * 2 - 1200ms + rand
-   * 3 - 2400ms + rand
-   * 4 - 4800ms + rand
-   * 5 - 9600ms + rand
-   */
+
   const timeout = ~~((Math.random() + 0.4) * (300 << attempts)); // Force a positive int in the case we make this an option
   await new Promise((resolve) => setTimeout((res) => resolve(res), timeout));
 }
@@ -20,6 +26,9 @@ interface StaggerOptions {
    * How many times the query will be retried (default: 5)
    */
   maxRetries?: number;
+  /**
+   * Function used to determine delay between retries
+   */
   backoff?: (attempt: number, maxRetries: number) => Promise<void>;
 }
 
@@ -57,4 +66,29 @@ const retryWithBackoff: BaseQueryEnhancer<unknown, StaggerOptions, StaggerOption
   }
 };
 
+/**
+ * A utility that can wrap `baseQuery` in the API definition to provide retries with a basic exponential backoff.
+ *
+ * @example
+ *
+ * ```ts title="Retry every request 5 times by default"
+ * // maxRetries: 5 is the default, and can be omitted. Shown for documentation purposes.
+ * const staggeredBaseQuery = retry(fetchBaseQuery({ baseUrl: '/' }), { maxRetries: 5 });
+ *
+ * export const api = createApi({
+ *   baseQuery: staggeredBaseQuery,
+ *   endpoints: (build) => ({
+ *     getPosts: build.query<PostsResponse, void>({
+ *       query: () => ({ url: 'posts' }),
+ *     }),
+ *     getPost: build.query<PostsResponse, void>({
+ *       query: (id: string) => ({ url: `posts/${id}` }),
+ *       extraOptions: { maxRetries: 8 }, // You can override the retry behavior on each endpoint
+ *     }),
+ *   }),
+ * });
+ *
+ * export const { useGetPostsQuery, useGetPostQuery } = api;
+ * ```
+ */
 export const retry = Object.assign(retryWithBackoff, { fail });

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -109,7 +109,7 @@ module.exports = {
                 extractorSettings: {
                   tsconfig: resolve(__dirname, '../docs/tsconfig.json'),
                   basedir: resolve(__dirname, '../src'),
-                  rootFiles: ['index.ts'],
+                  rootFiles: ['index.ts', 'react-hooks/ApiProvider.tsx'],
                 },
               },
             ],

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "clsx": "^1.1.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "remark-typescript-tools": "^1.0.3",
+    "remark-typescript-tools": "^1.0.4",
     "typescript": "^4.0.5"
   },
   "browserslist": {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8418,10 +8418,10 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remark-typescript-tools@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/remark-typescript-tools/-/remark-typescript-tools-1.0.3.tgz#7d1f3fd7c09a394e45ae89f6a8866ec6506d596a"
-  integrity sha512-qpugQhArrY4LhHhZThVq6krjJL9kuq/VPANUPK6EoyOIxN1oMPivBE1sdpsO0EU+AjSjUH8wFSTrKwYQ14Eufw==
+remark-typescript-tools@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/remark-typescript-tools/-/remark-typescript-tools-1.0.4.tgz#387ea0beab3502e59a1c70b1579f48e432b8c66d"
+  integrity sha512-bRDtrMve5riKqhz8hHE3ha/lmA72SVfml/R2ueF9MfJFnsluKwmt6pUORipnx6h3BGzFV55nPOW+vqEnT3FRww==
   dependencies:
     "@microsoft/tsdoc" "^0.12.21"
     prettier "^2.1.1"
@@ -9651,9 +9651,9 @@ unist-util-generated@^1.0.0:
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
 
 unist-util-is@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.4.tgz#3e9e8de6af2eb0039a59f50c9b3e99698a924f50"
-  integrity sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
+  integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
 
 unist-util-position@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION

### Changelog:
- Consolidate prettier config into single `.prettierrc` file
- Miscellaneous minor updates to existing docs pages
- Move portions of docs to docblock links
- Add docblocks to various items
- Update `remark-typescript-tools`

Little is actually proposed to change in the docs due to this PR, mainly things like:
- some spelling fixes
- some consistency fixes (e.g. updating type defs in the docs to match that in the code)

Where feasible, content that *could* be an imported docblock was made into an imported docblock.

Unless I missed some, all publicly exported items *excluding* typedefs should now have a docblock (and hence show additional info when hovered in the IDE). Type defs still need covering in the future.

Note: The intent was to introduce [prettier-plugin-jsdoc](https://github.com/hosseinmd/prettier-plugin-jsdoc) to allow prettier to format examples in docblocks, but it had some small quirks with how it formatted the rest of the docblock that made me decide to forego it at this stage.