### PR TITLE
selectFromResult for mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@types/jest": "^26.0.22",
     "immer": ">=8.0.0"
   },
   "peerDependencies": {
@@ -141,7 +142,7 @@
     "@rollup/plugin-replace": "^2.3.4",
     "@rollup/plugin-typescript": "^8.0.0",
     "@size-limit/preset-small-lib": "^4.6.0",
-    "@testing-library/react": "^11.1.0",
+    "@testing-library/react": "^11.2.6",
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/user-event": "^12.2.2",
     "@types/node-fetch": "^2.5.9",

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -132,9 +132,9 @@ export type MutationSubState<D extends BaseEndpointDefinition<any, any, any>> =
   | (({
       status: QueryStatus.fulfilled;
     } & WithRequiredProp<BaseMutationSubState<D>, 'data' | 'fulfilledTimeStamp'>) & { error: undefined })
-  | ({
+  | (({
       status: QueryStatus.pending;
-    } & BaseMutationSubState<D>)
+    } & BaseMutationSubState<D>) & { data?: undefined })
   | ({
       status: QueryStatus.rejected;
     } & WithRequiredProp<BaseMutationSubState<D>, 'error'>)

--- a/src/core/buildSelectors.ts
+++ b/src/core/buildSelectors.ts
@@ -53,6 +53,10 @@ type MutationResultSelector<Definition extends MutationDefinition<any, any, any,
   requestId: string | typeof skipSelector
 ) => (state: RootState) => MutationSubState<Definition> & RequestStatusFlags;
 
+export type MutationResultSelectorResult<
+  Definition extends MutationDefinition<any, any, any, any>
+> = MutationSubState<Definition> & RequestStatusFlags;
+
 const initialSubState = {
   status: QueryStatus.uninitialized as const,
 };

--- a/src/core/buildSelectors.ts
+++ b/src/core/buildSelectors.ts
@@ -51,7 +51,7 @@ export type QueryResultSelectorResult<
 
 type MutationResultSelector<Definition extends MutationDefinition<any, any, any, any>, RootState> = (
   requestId: string | typeof skipSelector
-) => (state: RootState) => MutationSubState<Definition> & RequestStatusFlags;
+) => (state: RootState) => MutationResultSelectorResult<Definition>;
 
 export type MutationResultSelectorResult<
   Definition extends MutationDefinition<any, any, any, any>

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -4,7 +4,6 @@ import {
   MutationSubState,
   QueryStatus,
   QuerySubState,
-  RequestStatusFlags,
   SubscriptionOptions,
   QueryKeys,
   RootState,
@@ -141,6 +140,8 @@ export type UseMutationStateOptions<D extends MutationDefinition<any, any, any, 
   selectFromResult?: MutationStateSelector<R, D>;
 };
 
+export type UseMutationStateResult<_ extends MutationDefinition<any, any, any, any>, R> = NoInfer<R>;
+
 type UseMutationStateBaseResult<D extends MutationDefinition<any, any, any, any>> = MutationSubState<D> & {
   /**
    * Mutation has not started yet.
@@ -180,7 +181,7 @@ export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R =
   ) => {
     unwrap: () => Promise<ResultTypeFrom<D>>;
   },
-  MutationSubState<D> & RequestStatusFlags
+  UseMutationStateResult<D, R>
 ];
 
 const defaultMutationStateSelector: DefaultMutationStateSelector<any> = (currentState) => {

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -146,9 +146,7 @@ export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R =
   UseMutationStateResult<D, R>
 ];
 
-const defaultMutationStateSelector: DefaultMutationStateSelector<any> = (currentState) => {
-  return currentState;
-};
+const defaultMutationStateSelector: DefaultMutationStateSelector<any> = (currentState) => currentState;
 
 const defaultQueryStateSelector: DefaultQueryStateSelector<any> = (currentState, lastResult) => {
   // data is the last known good request result we have tracked - or if none has been tracked yet the last good result for the current args

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -1,13 +1,6 @@
 import { AnyAction, createSelector, ThunkAction, ThunkDispatch } from '@reduxjs/toolkit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  MutationSubState,
-  QueryStatus,
-  QuerySubState,
-  SubscriptionOptions,
-  QueryKeys,
-  RootState,
-} from '../core/apiState';
+import { QueryStatus, QuerySubState, SubscriptionOptions, QueryKeys, RootState } from '../core/apiState';
 import {
   EndpointDefinitions,
   MutationDefinition,
@@ -142,8 +135,7 @@ export type UseMutationStateOptions<D extends MutationDefinition<any, any, any, 
 
 export type UseMutationStateResult<_ extends MutationDefinition<any, any, any, any>, R> = NoInfer<R>;
 
-
-export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R = UseMutationStateDefaultResult<D>>(
+export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R = MutationResultSelectorResult<D>>(
   options?: UseMutationStateOptions<D, R>
 ) => [
   (

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -4,6 +4,7 @@ import {
   MutationSubState,
   QueryStatus,
   QuerySubState,
+  RequestStatusFlags,
   SubscriptionOptions,
   QueryKeys,
   RootState,
@@ -140,8 +141,6 @@ export type UseMutationStateOptions<D extends MutationDefinition<any, any, any, 
   selectFromResult?: MutationStateSelector<R, D>;
 };
 
-export type UseMutationStateResult<_ extends MutationDefinition<any, any, any, any>, R> = NoInfer<R>;
-
 type UseMutationStateBaseResult<D extends MutationDefinition<any, any, any, any>> = MutationSubState<D> & {
   /**
    * Mutation has not started yet.
@@ -181,7 +180,7 @@ export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R =
   ) => {
     unwrap: () => Promise<ResultTypeFrom<D>>;
   },
-  UseMutationStateResult<D, R>
+  MutationSubState<D> & RequestStatusFlags
 ];
 
 const defaultMutationStateSelector: DefaultMutationStateSelector<any> = (currentState) => {

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -146,23 +146,19 @@ export type UseMutationStateResult<_ extends MutationDefinition<any, any, any, a
 
 type UseMutationStateBaseResult<D extends MutationDefinition<any, any, any, any>> = MutationSubState<D> & {
   /**
-   * Query has not started yet.
+   * Mutation has not started yet.
    */
   isUninitialized: false;
   /**
-   * Query is currently loading for the first time. No data yet.
+   * Mutation is currently loading for the first time. No data yet.
    */
   isLoading: false;
   /**
-   * Query is currently fetching, but might have data from an earlier request.
-   */
-  isFetching: false;
-  /**
-   * Query has data from a successful load.
+   * Mutation has data from a successful load.
    */
   isSuccess: false;
   /**
-   * Query is currently in "error" state.
+   * Mutation is currently in "error" state.
    */
   isError: false;
 };
@@ -486,12 +482,6 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
         (state: RootState<Definitions, any, any>) => mutationSelector(state),
         shallowEqual
       );
-
-      // We should check the result, and if it's null or an empty object, it should not rerender
-      // We should also track the last results and force an update if they're not deepEqual?
-
-      // const mutationSelector = useMemo(() => select(requestId || skipSelector), [requestId, select]);
-      // const currentState = useSelector(mutationSelector);
 
       return useMemo(() => [triggerMutation, currentState], [triggerMutation, currentState]);
     };

--- a/src/ts41Types.ts
+++ b/src/ts41Types.ts
@@ -1,4 +1,4 @@
-import { MutationHook, UseLazyQuery, UseQuery } from './react-hooks/buildHooks';
+import { UseMutation, UseLazyQuery, UseQuery } from './react-hooks/buildHooks';
 import { DefinitionType, EndpointDefinitions, MutationDefinition, QueryDefinition } from './endpointDefinitions';
 
 export type TS41Hooks<Definitions extends EndpointDefinitions> = keyof Definitions extends infer Keys
@@ -16,7 +16,7 @@ export type TS41Hooks<Definitions extends EndpointDefinitions> = keyof Definitio
           }
       : Definitions[Keys] extends { type: DefinitionType.mutation }
       ? {
-          [K in Keys as `use${Capitalize<K>}Mutation`]: MutationHook<
+          [K in Keys as `use${Capitalize<K>}Mutation`]: UseMutation<
             Extract<Definitions[K], MutationDefinition<any, any, any, any>>
           >;
         }

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -1330,7 +1330,7 @@ describe('hooks with createApi defaults set', () => {
 
     let getRenderCount: () => number = () => 0;
 
-    it('does not cause a rerender when using selectFromResult with an empty object', async () => {
+    it('causes no more than one rerender when using selectFromResult with an empty object', async () => {
       function Counter() {
         const [increment] = api.endpoints.increment.useMutation({
           selectFromResult: () => ({}),

--- a/test/unionTypes.test.ts
+++ b/test/unionTypes.test.ts
@@ -328,7 +328,7 @@ describe.skip('TS only tests', () => {
       expectExactType(false as false)(result.isSuccess);
     }
     if (result.isLoading) {
-      expectExactType(undefined as string | undefined)(result.data);
+      expectExactType(undefined as undefined)(result.data);
       expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
 
       expectExactType(false as false)(result.isUninitialized);
@@ -373,7 +373,7 @@ describe.skip('TS only tests', () => {
       expectExactType(false as false)(result.isSuccess);
     }
     if (result.isLoading) {
-      expectExactType(undefined as string | undefined)(result.data);
+      expectExactType(undefined as undefined)(result.data);
       expectExactType(undefined as SerializedError | FetchBaseQueryError | undefined)(result.error);
 
       expectExactType(false as false)(result.isUninitialized);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,10 +1303,10 @@
     "@babel/runtime" "^7.12.5"
     "@types/testing-library__react-hooks" "^3.4.0"
 
-"@testing-library/react@^11.1.0":
-  version "11.2.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
-  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+"@testing-library/react@^11.2.6":
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
+  integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
@@ -1421,7 +1421,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^25.2.1", "@types/jest@^26.0.15":
+"@types/jest@^25.2.1", "@types/jest@^26.0.15", "@types/jest@^26.0.22":
   version "26.0.22"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
   integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==


### PR DESCRIPTION
- Adds `selectFromResult` option for `useMutation()`. 
  - This allows a user to 'optimize renders' by _only_ rerendering when the selected values change. There will always be 1 rerender when the mutation is called as it creates a new `requestId`. For the most performant implementation, you can `yourEndpoint.useMutation(undefined, { selectFromResult: () => ({}) })`
  - All possible usages can be seen in the tests with the appropriate assertions :sweat_smile: 