### PR TITLE
Miscellaneous documentation work

### DIFF
--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -147,7 +147,7 @@ const api = createApi({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) => result.map(({ id }) => ({ type: 'Posts', id })),
+      provides: (result) => result ? result.map(({ id }) => ({ type: 'Posts', id })) : [],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({

--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -29,30 +29,7 @@ The main point where you will define a service to use in your application.
 
 [summary](docblock://createApi.ts?token=CreateApiOptions.baseQuery)
 
-```ts title="Simulating axios-like interceptors with a custom base query"
-const baseQuery = fetchBaseQuery({ baseUrl: '/' });
-
-const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
-  args,
-  api,
-  extraOptions
-) => {
-  let result = await baseQuery(args, api, extraOptions);
-  if (result.error && result.error.status === '401') {
-    // try to get a new token
-    const refreshResult = await baseQuery('/refreshToken', api, extraOptions);
-    if (refreshResult.data) {
-      // store the new token
-      api.dispatch(setToken(refreshResult.data));
-      // retry the initial query
-      result = await baseQuery(args, api, extraOptions);
-    } else {
-      api.dispatch(loggedOut());
-    }
-  }
-  return result;
-};
-```
+[examples](docblock://createApi.ts?token=CreateApiOptions.baseQuery)
 
 ### `entityTypes`
 
@@ -62,29 +39,12 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
 
 [summary](docblock://createApi.ts?token=CreateApiOptions.reducerPath)
 
-```js title="apis.js"
-import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
-
-const apiOne = createApi({
-  reducerPath: 'apiOne',
-  baseQuery: fetchBaseQuery('/'),
-  endpoints: (builder) => ({
-    // ...endpoints
-  }),
-});
-
-const apiTwo = createApi({
-  reducerPath: 'apiTwo',
-  baseQuery: fetchBaseQuery('/'),
-  endpoints: (builder) => ({
-    // ...endpoints
-  }),
-});
-```
+[examples](docblock://createApi.ts?token=CreateApiOptions.reducerPath)
 
 ### `serializeQueryArgs`
 
-[summary](docblock://createApi.ts?token=CreateApiOptions.reducerPath)
+[summary](docblock://createApi.ts?token=CreateApiOptions.serializeQueryArgs)
+
 Defaults to:
 
 ```ts no-compile
@@ -217,17 +177,11 @@ export const api = createApi({
 
 ### `keepUnusedDataFor`
 
-Defaults to `60` _(this value is in seconds)_. This is how long RTK Query will keep your data cached for **after** the last component unsubscribes. For example, if you query an endpoint, then unmount the component, then mount another component that makes the same request within the given time frame, the most recent value will be served from the cache.
+[summary](docblock://createApi.ts?token=CreateApiOptions.keepUnusedDataFor)
 
 ### `refetchOnMountOrArgChange`
 
-Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
-
-- `false` - Will not cause a query to be performed _unless_ it does not exist yet.
-- `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
-- `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.
-
-If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+[summary](docblock://createApi.ts?token=CreateApiOptions.refetchOnMountOrArgChange)
 
 :::note
 You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnMountOrArgChange` to each individual hook call or when dispatching the [`initiate`](#initiate) action.
@@ -235,9 +189,7 @@ You can set this globally in `createApi`, but you can also override the default 
 
 ### `refetchOnFocus`
 
-Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
-
-If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+[summary](docblock://createApi.ts?token=CreateApiOptions.refetchOnFocus)
 
 :::note
 You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnFocus` to each individual hook call or when dispatching the [`initiate`](#initiate) action.
@@ -247,9 +199,7 @@ If you specify `track: false` when manually dispatching queries, RTK Query will 
 
 ### `refetchOnReconnect`
 
-Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
-
-If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+[summary](docblock://createApi.ts?token=CreateApiOptions.refetchOnReconnect)
 
 :::note
 You can set this globally in `createApi`, but you can also override the default value and have more granular control by passing `refetchOnReconnect` to each individual hook call or when dispatching the [`initiate`](#initiate) action.

--- a/docs/concepts/code-generation.md
+++ b/docs/concepts/code-generation.md
@@ -28,11 +28,16 @@ export const api = generatedApi.enhanceEndpoints({
   endpoints: {
     // basic notation: just specify properties to be overridden
     getPetById: {
-      provides: (result) => (result ? [{ type: 'Pet', id: result.id }] : []),
+      provides: (result, error, arg) => (result ? [{ type: 'Pet', id: arg.petId }] : []),
     },
     findPetsByStatus: {
       provides: (result) =>
-        result ? [{ type: 'Pet', id: 'LIST' }, ...result.map((pet) => ({ type: 'Pet' as const, id: pet.id }))] : [],
+        // is result available?
+        result ? 
+          // successful query
+          [{ type: 'Pet', id: 'LIST' }, ...result.map((pet) => ({ type: 'Pet' as const, id: pet.id }))] : 
+          // an error occured, but we still want to refetch this query when `{ type: 'Pet', id: 'LIST' }` is invalidated
+          [{ type: 'Pet', id: 'LIST' }],
     },
     // alternate notation: callback that gets passed in `endpoint` - you can freely modify the object here
     addPet: (endpoint) => {

--- a/docs/concepts/code-generation.md
+++ b/docs/concepts/code-generation.md
@@ -28,13 +28,11 @@ export const api = generatedApi.enhanceEndpoints({
   endpoints: {
     // basic notation: just specify properties to be overridden
     getPetById: {
-      provides: (response) => [{ type: 'Pet', id: response.id }],
+      provides: (result) => (result ? [{ type: 'Pet', id: result.id }] : []),
     },
     findPetsByStatus: {
-      provides: (response) => [
-        { type: 'Pet', id: 'LIST' },
-        ...response.map((pet) => ({ type: 'Pet' as const, id: pet.id })),
-      ],
+      provides: (result) =>
+        result ? [{ type: 'Pet', id: 'LIST' }, ...result.map((pet) => ({ type: 'Pet' as const, id: pet.id }))] : [],
     },
     // alternate notation: callback that gets passed in `endpoint` - you can freely modify the object here
     addPet: (endpoint) => {
@@ -44,7 +42,7 @@ export const api = generatedApi.enhanceEndpoints({
       invalidates: (response) => [{ type: 'Pet', id: response.id }],
     },
     deletePet: {
-      invalidates: (_, arg) => [{ type: 'Pet', id: arg.petId }],
+      invalidates: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
   },
 });

--- a/docs/concepts/code-generation.md
+++ b/docs/concepts/code-generation.md
@@ -28,23 +28,23 @@ export const api = generatedApi.enhanceEndpoints({
   endpoints: {
     // basic notation: just specify properties to be overridden
     getPetById: {
-      provides: (result, error, arg) => (result ? [{ type: 'Pet', id: arg.petId }] : []),
+      provides: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
     findPetsByStatus: {
       provides: (result) =>
         // is result available?
-        result ? 
-          // successful query
-          [{ type: 'Pet', id: 'LIST' }, ...result.map((pet) => ({ type: 'Pet' as const, id: pet.id }))] : 
-          // an error occured, but we still want to refetch this query when `{ type: 'Pet', id: 'LIST' }` is invalidated
-          [{ type: 'Pet', id: 'LIST' }],
+        result
+          ? // successful query
+            [{ type: 'Pet', id: 'LIST' }, ...result.map((pet) => ({ type: 'Pet' as const, id: pet.id }))]
+          : // an error occurred, but we still want to refetch this query when `{ type: 'Pet', id: 'LIST' }` is invalidated
+            [{ type: 'Pet', id: 'LIST' }],
     },
     // alternate notation: callback that gets passed in `endpoint` - you can freely modify the object here
     addPet: (endpoint) => {
-      endpoint.invalidates = (response) => [{ type: 'Pet', id: response.id }];
+      endpoint.invalidates = (result) => [{ type: 'Pet', id: result.id }];
     },
     updatePet: {
-      invalidates: (response) => [{ type: 'Pet', id: response.id }],
+      invalidates: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
     deletePet: {
       invalidates: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],

--- a/docs/concepts/conditional-fetching.md
+++ b/docs/concepts/conditional-fetching.md
@@ -9,31 +9,9 @@ hide_title: true
 
 If you want to prevent a query from automatically running, you can use the `skip` parameter in a hook.
 
-```ts title="Skip example"
-const Pokemon = ({ name, skip }: { name: string; skip: boolean }) => {
-  const { data, error, status } = useGetPokemonByNameQuery(name, {
-    skip,
-  });
+[examples](docblock://react-hooks/buildHooks.ts?token=UseQuerySubscriptionOptions.skip)
 
-  return (
-    <div>
-      {name} - {status}
-    </div>
-  );
-};
-```
-
-When `skip` is `true`:
-
-- **If the query has cached data:**
-  - The cached data **will not be used** on the initial load, and will ignore updates from any identical query until the `skip` condition is removed
-  - The query will have a status of `uninitialized`
-  - If a `skip: false` is set after skipping the initial load, the cached result will be used
-- **If the query does not have cached data**
-  - The query will have a status of `uninitialized`
-  - The query will not exist in the state when viewed with the dev tools
-  - The query will not automatically fetch on mount
-  - The query will not automatically run when additional components with the same query are added that do run
+[remarks](docblock://react-hooks/buildHooks.ts?token=UseQuerySubscriptionOptions.skip)
 
 ### Example
 

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -156,7 +156,7 @@ export const api = createApi({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
+      provides: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });
@@ -211,7 +211,7 @@ export const api = createApi({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
+      provides: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });
@@ -272,12 +272,12 @@ export const postApi = createApi({
       // If any mutation is executed that `invalidate`s any of these entities, this query will re-run to be always up-to-date.
       // The `LIST` id is a "virtual id" we just made up to be able to invalidate this query specifically if a new `Posts` element was added.
       provides: (result) =>
-      // is result available?
-      result ? 
-        // successful query
-        [...result.map(({ id }) => ({ type: 'Posts', id })), { type: 'Posts', id: 'LIST' }] : 
-        // an error occured, but we still want to refetch this query when `{ type: 'Posts', id: 'LIST' }` is invalidated
-        [{ type: 'Posts', id: 'LIST' }],
+        // is result available?
+        result
+          ? // successful query
+            [...result.map(({ id }) => ({ type: 'Posts', id })), { type: 'Posts', id: 'LIST' }]
+          : // an error occurred, but we still want to refetch this query when `{ type: 'Posts', id: 'LIST' }` is invalidated
+            [{ type: 'Posts', id: 'LIST' }],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query(body) {

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -125,11 +125,11 @@ For RTK Query, _entities_ are just a name that you can give to a specific collec
 
 #### Provides
 
-A _query_ can _provide_ entities to the cache. The `provides` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either result or error arguments may be undefined based on whether the query was successful or not.
+A _query_ can _provide_ entities to the cache. The `provides` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the query was successful or not.
 
 #### Invalidates
 
-A _mutation_ can _invalidate_ specific entities in the cache. The `invalidates` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the second argument. Note that either result or error arguments may be undefined based on whether the mutation was successful or not.
+A _mutation_ can _invalidate_ specific entities in the cache. The `invalidates` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the mutation was successful or not.
 
 ### Scenarios and Behaviors
 
@@ -144,7 +144,7 @@ export const api = createApi({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
+      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : ['Posts']),
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({
@@ -197,7 +197,9 @@ export const api = createApi({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
       provides: (result) =>
-        result ? [...result.map(({ id }) => ({ type: 'Posts', id })), { type: 'Posts', id: 'LIST' }] : [],
+        result
+          ? [...result.map(({ id }) => ({ type: 'Posts', id })), { type: 'Posts', id: 'LIST' }]
+          : [{ type: 'Posts', id: 'LIST' }],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query(body) {

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -26,7 +26,7 @@ const api = createApi({
       // `result` is the server response
       onSuccess(id, queryApi, result) {},
       onError(id, queryApi) {},
-      provides: (_, id) => [{ type: 'Post', id }],
+      provides: (result, error, id) => (result ? [{ type: 'Post', id }] : []),
     }),
   }),
 });
@@ -115,7 +115,9 @@ The way that this component is setup would have some nice traits:
 
 ### Selecting data from a query result
 
-Sometimes you may have a parent component that is subscribed to a query, and then in a child component you want to pick an item from that query. In most cases you don't want to perform an additional request for a `getItemById`-type query when you know that you already have the result. `selectFromResult` allows you to get a specific segment from a query result in a performant manner. When using this feature, the component will not rerender unless the underlying data of the selected item has changed. If the selected item is one element in a larger collection, it will disregard changes to elements in the same collection.
+Sometimes you may have a parent component that is subscribed to a query, and then in a child component you want to pick an item from that query. In most cases you don't want to perform an additional request for a `getItemById`-type query when you know that you already have the result.
+
+`selectFromResult` allows you to get a specific segment from a query result in a performant manner. When using this feature, the component will not rerender unless the underlying data of the selected item has changed. If the selected item is one element in a larger collection, it will disregard changes to elements in the same collection.
 
 ```ts title="Using selectFromResult to extract a single result"
 function PostsList() {

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -26,7 +26,7 @@ const api = createApi({
       // `result` is the server response
       onSuccess(id, queryApi, result) {},
       onError(id, queryApi) {},
-      provides: (result, error, id) => (result ? [{ type: 'Post', id }] : []),
+      provides: (result, error, id) => [{ type: 'Post', id }],
     }),
   }),
 });

--- a/examples/react/src/app/services/posts.ts
+++ b/examples/react/src/app/services/posts.ts
@@ -48,7 +48,9 @@ export const postApi = createApi({
     getPosts: build.query<PostsResponse, void>({
       query: () => ({ url: 'posts' }),
       provides: (result) =>
-        result ? [...result.map(({ id }) => ({ type: 'Posts', id } as const)), { type: 'Posts', id: 'LIST' }] : [{ type: 'Posts', id: 'LIST' }],
+        result
+          ? [...result.map(({ id }) => ({ type: 'Posts', id } as const)), { type: 'Posts', id: 'LIST' }]
+          : [{ type: 'Posts', id: 'LIST' }],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({

--- a/examples/react/src/app/services/posts.ts
+++ b/examples/react/src/app/services/posts.ts
@@ -47,10 +47,8 @@ export const postApi = createApi({
     }),
     getPosts: build.query<PostsResponse, void>({
       query: () => ({ url: 'posts' }),
-      provides: (result) => [
-        ...result.map(({ id }) => ({ type: 'Posts', id } as const)),
-        { type: 'Posts', id: 'LIST' },
-      ],
+      provides: (result) =>
+        result ? [...result.map(({ id }) => ({ type: 'Posts', id } as const)), { type: 'Posts', id: 'LIST' }] : [],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({
@@ -62,7 +60,7 @@ export const postApi = createApi({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (_, id) => [{ type: 'Posts', id }],
+      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
     }),
     updatePost: build.mutation<Post, Partial<Post>>({
       query(data) {
@@ -73,7 +71,7 @@ export const postApi = createApi({
           body,
         };
       },
-      invalidates: (_, { id }) => [{ type: 'Posts', id }],
+      invalidates: (result, error, { id }) => [{ type: 'Posts', id }],
     }),
     deletePost: build.mutation<{ success: boolean; id: number }, number>({
       query(id) {
@@ -82,7 +80,7 @@ export const postApi = createApi({
           method: 'DELETE',
         };
       },
-      invalidates: (_, id) => [{ type: 'Posts', id }],
+      invalidates: (result, error, id) => [{ type: 'Posts', id }],
     }),
     getErrorProne: build.query<{ success: boolean }, void>({
       query: () => 'error-prone',

--- a/examples/react/src/app/services/posts.ts
+++ b/examples/react/src/app/services/posts.ts
@@ -48,7 +48,7 @@ export const postApi = createApi({
     getPosts: build.query<PostsResponse, void>({
       query: () => ({ url: 'posts' }),
       provides: (result) =>
-        result ? [...result.map(({ id }) => ({ type: 'Posts', id } as const)), { type: 'Posts', id: 'LIST' }] : [],
+        result ? [...result.map(({ id }) => ({ type: 'Posts', id } as const)), { type: 'Posts', id: 'LIST' }] : [{ type: 'Posts', id: 'LIST' }],
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({
@@ -60,7 +60,7 @@ export const postApi = createApi({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
+      provides: (result, error, id) => [{ type: 'Posts', id }],
     }),
     updatePost: build.mutation<Post, Partial<Post>>({
       query(data) {

--- a/examples/react/src/app/services/split/post.ts
+++ b/examples/react/src/app/services/split/post.ts
@@ -14,7 +14,7 @@ export const apiWithPost = emptySplitApi.injectEndpoints({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
+      provides: (result, error, id) => [{ type: 'Posts', id }],
     }),
     updatePost: build.mutation<Post, Partial<Post>>({
       query(data) {

--- a/examples/react/src/app/services/split/post.ts
+++ b/examples/react/src/app/services/split/post.ts
@@ -14,7 +14,7 @@ export const apiWithPost = emptySplitApi.injectEndpoints({
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (_, id) => [{ type: 'Posts', id }],
+      provides: (result, error, id) => (result ? [{ type: 'Posts', id }] : []),
     }),
     updatePost: build.mutation<Post, Partial<Post>>({
       query(data) {
@@ -25,7 +25,7 @@ export const apiWithPost = emptySplitApi.injectEndpoints({
           body,
         };
       },
-      invalidates: (_, { id }) => [{ type: 'Posts', id }],
+      invalidates: (result, error, { id }) => [{ type: 'Posts', id }],
     }),
     deletePost: build.mutation<{ success: boolean; id: number }, number>({
       query(id) {
@@ -34,7 +34,7 @@ export const apiWithPost = emptySplitApi.injectEndpoints({
           method: 'DELETE',
         };
       },
-      invalidates: (_, id) => [{ type: 'Posts', id }],
+      invalidates: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });

--- a/examples/react/src/app/services/split/posts.ts
+++ b/examples/react/src/app/services/split/posts.ts
@@ -4,7 +4,7 @@ export const apiWithPosts = emptySplitApi.injectEndpoints({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) => result.map(({ id }) => ({ type: 'Posts', id })),
+      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
     }),
   }),
 });

--- a/examples/react/src/app/services/split/posts.ts
+++ b/examples/react/src/app/services/split/posts.ts
@@ -4,7 +4,7 @@ export const apiWithPosts = emptySplitApi.injectEndpoints({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
+      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : ['Posts']),
     }),
   }),
 });

--- a/examples/react/src/app/services/times.ts
+++ b/examples/react/src/app/services/times.ts
@@ -11,7 +11,7 @@ export const timeApi = createApi({
   endpoints: (build) => ({
     getTime: build.query<TimeResponse, string>({
       query: (id) => `time/${id}`,
-      provides: (result, error, id) => (result ? [{ type: 'Time', id }] : []),
+      provides: (result, error, id) => [{ type: 'Time', id }],
     }),
   }),
   refetchOnReconnect: true,

--- a/examples/react/src/app/services/times.ts
+++ b/examples/react/src/app/services/times.ts
@@ -11,7 +11,7 @@ export const timeApi = createApi({
   endpoints: (build) => ({
     getTime: build.query<TimeResponse, string>({
       query: (id) => `time/${id}`,
-      provides: (_, id) => [{ type: 'Time', id }],
+      provides: (result, error, id) => (result ? [{ type: 'Time', id }] : []),
     }),
   }),
   refetchOnReconnect: true,

--- a/examples/svelte/src/services/counter.ts
+++ b/examples/svelte/src/services/counter.ts
@@ -39,7 +39,7 @@ export const counterApi = createApi({
         }),
         getCountById: build.query<CountResponse, string>({
             query: (id: string) => `${id}`,
-            provides: (result, error, id) => (result ? [{ type: 'Counter', id }] : []),
+            provides: (result, error, id) => [{ type: 'Counter', id }],
         }),
         incrementCountById: build.mutation<CountResponse, { id: string; amount: number }>({
             query: ({ id, amount }) => ({

--- a/examples/svelte/src/services/counter.ts
+++ b/examples/svelte/src/services/counter.ts
@@ -39,7 +39,7 @@ export const counterApi = createApi({
         }),
         getCountById: build.query<CountResponse, string>({
             query: (id: string) => `${id}`,
-            provides: (_, id) => [{ type: 'Counter', id }],
+            provides: (result, error, id) => (result ? [{ type: 'Counter', id }] : []),
         }),
         incrementCountById: build.mutation<CountResponse, { id: string; amount: number }>({
             query: ({ id, amount }) => ({
@@ -47,7 +47,7 @@ export const counterApi = createApi({
                 method: 'PUT',
                 body: { amount },
             }),
-            invalidates: (_, { id }) => [{ type: 'Counter', id }],
+            invalidates: (result, error, { id }) => [{ type: 'Counter', id }],
         }),
         decrementCountById: build.mutation<CountResponse, { id: string; amount: number }>({
             query: ({ id, amount }) => ({
@@ -55,7 +55,7 @@ export const counterApi = createApi({
                 method: 'PUT',
                 body: { amount },
             }),
-            invalidates: (_, { id }) => [{ type: 'Counter', id }],
+            invalidates: (result, error, { id }) => [{ type: 'Counter', id }],
         }),
         stop: build.mutation<any, void>({
             query: () => ({

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -72,7 +72,7 @@ export function getRequestStatusFlags(status: QueryStatus): RequestStatusFlags {
 
 export type SubscriptionOptions = {
   /**
-   * How frequently to automatically re-fetch data. Defaults to `0` (off).
+   * How frequently to automatically re-fetch data (in milliseconds). Defaults to `0` (off).
    */
   pollingInterval?: number;
   /**

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -71,8 +71,25 @@ export function getRequestStatusFlags(status: QueryStatus): RequestStatusFlags {
 }
 
 export type SubscriptionOptions = {
+  /**
+   * How frequently to automatically re-fetch data. Defaults to `0` (off).
+   */
   pollingInterval?: number;
+  /**
+   * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
+   *
+   * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   *
+   * Note: requires `setupListeners` to have been called.
+   */
   refetchOnReconnect?: boolean;
+  /**
+   * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
+   *
+   * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   *
+   * Note: requires `setupListeners` to have been called.
+   */
   refetchOnFocus?: boolean;
 };
 export type Subscribers = { [requestId: string]: SubscriptionOptions };
@@ -85,13 +102,31 @@ export type MutationKeys<Definitions extends EndpointDefinitions> = {
 
 type BaseQuerySubState<D extends BaseEndpointDefinition<any, any, any>> = {
   originalArgs: QueryArgFrom<D>;
+  /**
+   * A unique ID associated with the request
+   */
   requestId: string;
+  /**
+   * The received data from the query
+   */
   data?: ResultTypeFrom<D>;
+  /**
+   * The received error if applicable
+   */
   error?:
     | SerializedError
     | (D extends QueryDefinition<any, infer BaseQuery, any, any> ? BaseQueryError<BaseQuery> : never);
+  /**
+   * The name of the endpoint associated with the query
+   */
   endpointName: string;
+  /**
+   * Time that the latest query started
+   */
   startedTimeStamp: number;
+  /**
+   * Time that the latest query was fulfilled
+   */
   fulfilledTimeStamp?: number;
 };
 

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -101,6 +101,9 @@ export type MutationKeys<Definitions extends EndpointDefinitions> = {
 }[keyof Definitions];
 
 type BaseQuerySubState<D extends BaseEndpointDefinition<any, any, any>> = {
+  /**
+   * The argument originally passed into the hook or `initiate` action call
+   */
   originalArgs: QueryArgFrom<D>;
   /**
    * A unique ID associated with the request

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -46,12 +46,16 @@ export interface CreateApiOptions<
    * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after the application window regains focus.
    *
    * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   *
+   * Note: requires `setupListeners` to have been called.
    */
   refetchOnFocus?: boolean;
   /**
    * Defaults to `false`. This setting allows you to control whether RTK Query will try to refetch all subscribed queries after regaining a network connection.
    *
    * If you specify this option alongside `skip: true`, this **will not be evaluated** until `skip` is false.
+   *
+   * Note: requires `setupListeners` to have been called.
    */
   refetchOnReconnect?: boolean;
 }

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -89,6 +89,9 @@ export interface QueryApi<ReducerPath extends string, Context extends {}> {
    * A unique ID generated for the mutation
    */
   requestId: string;
+  /**
+  * A variable shared between `onStart`, `onError` and `onSuccess` of one request to pass data forward between them
+  */
   context: Context;
 }
 
@@ -277,7 +280,7 @@ export type EndpointBuilder<BaseQuery extends BaseQueryFn, EntityTypes extends s
    *      // `result` is the server response
    *      onSuccess(id, queryApi, result) {},
    *      onError(id, queryApi) {},
-   *      provides: (result, error, id) => (result ? [{ type: 'Post', id }] : []),
+   *      provides: (result, error, id) => [{ type: 'Post', id }],
    *    }),
    *  }),
    *});
@@ -305,7 +308,7 @@ export type EndpointBuilder<BaseQuery extends BaseQueryFn, EntityTypes extends s
    *       // `result` is the server response
    *       onSuccess({ id }, mutationApi, result) {},
    *       onError({ id }, { dispatch, getState, extra, requestId, context }) {},
-   *       invalidates: ['Post'],
+   *       invalidates: (result, error, id) => [{ type: 'Post', id }],
    *     }),
    *   }),
    * });

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -85,16 +85,16 @@ export interface QueryApi<ReducerPath extends string, Context extends {}> {
    */
   getState(): RootState<any, any, ReducerPath>;
   /**
-  * `extra` as provided as `thunk.extraArgument` to the `configureStore` `getDefaultMiddleware` option.
-  */
+   * `extra` as provided as `thunk.extraArgument` to the `configureStore` `getDefaultMiddleware` option.
+   */
   extra: unknown;
   /**
    * A unique ID generated for the mutation
    */
   requestId: string;
   /**
-  * A variable shared between `onStart`, `onError` and `onSuccess` of one request to pass data forward between them
-  */
+   * A variable shared between `onStart`, `onError` and `onSuccess` of one request to pass data forward between them
+   */
   context: Context;
 }
 

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -108,11 +108,11 @@ interface QueryExtraOptions<
 > {
   type: DefinitionType.query;
   /**
-   * Used by `queries` to provide entities to the cache.
-   * Expects an array of entity type strings, or an array of objects of entity types with ids.
-   * 1.  `['Post']` - equivalent to `ii`
-   * 2.  `[{ type: 'Post' }]` - equivalent to `i`
-   * 3.  `[{ type: 'Post', id: 1 }]`
+   * - Used by `queries` to provide entities to the cache.
+   * - Expects an array of entity type strings, or an array of objects of entity types with ids.
+   *   1.  `['Post']` - equivalent to `b`
+   *   2.  `[{ type: 'Post' }]` - equivalent to `a`
+   *   3.  `[{ type: 'Post', id: 1 }]`
    */
   provides?: ResultDescription<EntityTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   /**
@@ -172,11 +172,17 @@ export interface MutationApi<ReducerPath extends string, Context extends {}> {
    * A method to get the current state
    */
   getState(): RootState<any, any, ReducerPath>;
+  /**
+   * `extra` as provided as `thunk.extraArgument` to the `configureStore` `getDefaultMiddleware` option.
+   */
   extra: unknown;
   /**
    * A unique ID generated for the mutation
    */
   requestId: string;
+  /**
+   * A variable shared between `onStart`, `onError` and `onSuccess` of one request to pass data forward between them
+   */
   context: Context;
 }
 
@@ -190,8 +196,8 @@ interface MutationExtraOptions<
 > {
   type: DefinitionType.mutation;
   /**
-   * Used by `mutations` for [cache invalidation](../concepts/mutations#advanced-mutations-with-revalidation) purposes.
-   * Expects the same shapes as `provides`
+   * - Used by `mutations` for [cache invalidation](../concepts/mutations#advanced-mutations-with-revalidation) purposes.
+   * - Expects the same shapes as `provides`.
    */
   invalidates?: ResultDescription<EntityTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   /**

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -84,6 +84,9 @@ export interface QueryApi<ReducerPath extends string, Context extends {}> {
    * A method to get the current state
    */
   getState(): RootState<any, any, ReducerPath>;
+  /**
+  * `extra` as provided as `thunk.extraArgument` to the `configureStore` `getDefaultMiddleware` option.
+  */
   extra: unknown;
   /**
    * A unique ID generated for the mutation

--- a/src/react-hooks/ApiProvider.tsx
+++ b/src/react-hooks/ApiProvider.tsx
@@ -8,7 +8,8 @@ import { Api } from '../apiTypes';
  * Can be used as a `Provider` if you **do not already have a Redux store**.
  *
  * @example
- * ```ts title="Basic usage - wrap your App with ApiProvider"
+ * ```ts
+ * // codeblock-meta title="Basic usage - wrap your App with ApiProvider"
  * import * as React from 'react';
  * import { ApiProvider } from '@rtk-incubator/rtk-query';
  *

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -249,6 +249,17 @@ export type MutationHook<D extends MutationDefinition<any, any, any, any>> = () 
      *   .then((payload) => console.log('fulfilled', payload))
      *   .catch((error) => console.error('rejected', error));
      * ```
+     *
+     * @example
+     * ```ts
+     * // codeblock-meta title="Using .unwrap with async await"
+     * try {
+     *   const payload = await addPost({ id: 1, name: 'Example' }).unwrap();
+     *   console.log('fulfilled', payload)
+     * } catch (error) {
+     *   console.error('rejected', error);
+     * }
+     * ```
      */
     unwrap: () => Promise<ResultTypeFrom<D>>;
   },

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -78,7 +78,7 @@ interface UseQuerySubscriptionOptions extends SubscriptionOptions {
    */
   skip?: boolean;
   /**
-   * Defaults to `false`. This setting allows you to control whether RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
+   * Defaults to `false`. This setting allows you to control whether if a cached result is already available, RTK Query will only serve a cached result, or if it should `refetch` when set to `true` or if an adequate amount of time has passed since the last successful query result.
    * - `false` - Will not cause a query to be performed _unless_ it does not exist yet.
    * - `true` - Will always refetch when a new subscriber to a query is added. Behaves the same as calling the `refetch` callback or passing `forceRefetch: true` in the action creator.
    * - `number` - **Value is in seconds**. If a number is provided and there is an existing query in the cache, it will compare the current time vs the last fulfilled timestamp, and only refetch if enough time has elapsed.

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -71,7 +71,8 @@ const retryWithBackoff: BaseQueryEnhancer<unknown, StaggerOptions, StaggerOption
  *
  * @example
  *
- * ```ts title="Retry every request 5 times by default"
+ * ```ts
+ * // codeblock-meta title="Retry every request 5 times by default"
  * // maxRetries: 5 is the default, and can be omitted. Shown for documentation purposes.
  * const staggeredBaseQuery = retry(fetchBaseQuery({ baseUrl: '/' }), { maxRetries: 5 });
  *

--- a/src/tsHelpers.ts
+++ b/src/tsHelpers.ts
@@ -8,7 +8,7 @@ export function safeAssign<T extends object>(target: T, ...args: Array<Partial<N
 }
 
 /**
- * Convert a Union type `(A|B)` to and intersecion type `(A&B)`
+ * Convert a Union type `(A|B)` to an intersection type `(A&B)`
  */
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -1105,7 +1105,7 @@ describe('hooks with createApi defaults set', () => {
             method: 'PUT',
             body,
           }),
-          invalidates: (result) => (result ? [{ type: 'Posts', id: result.id }] : []),
+          invalidates: (result, error, { id }) => [{ type: 'Posts', id }],
         }),
         addPost: build.mutation<Post, Partial<Post>>({
           query: (body) => ({

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -109,7 +109,7 @@ module.exports = {
                 extractorSettings: {
                   tsconfig: resolve(__dirname, '../docs/tsconfig.json'),
                   basedir: resolve(__dirname, '../src'),
-                  rootFiles: ['index.ts', 'react-hooks/ApiProvider.tsx'],
+                  rootFiles: ['index.ts', 'react.ts', 'react-hooks/ApiProvider.tsx'],
                 },
               },
             ],

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "clsx": "^1.1.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "remark-typescript-tools": "^1.0.4",
+    "remark-typescript-tools": "1.0.5",
     "typescript": "^4.0.5"
   },
   "browserslist": {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8418,10 +8418,10 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remark-typescript-tools@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/remark-typescript-tools/-/remark-typescript-tools-1.0.4.tgz#387ea0beab3502e59a1c70b1579f48e432b8c66d"
-  integrity sha512-bRDtrMve5riKqhz8hHE3ha/lmA72SVfml/R2ueF9MfJFnsluKwmt6pUORipnx6h3BGzFV55nPOW+vqEnT3FRww==
+remark-typescript-tools@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/remark-typescript-tools/-/remark-typescript-tools-1.0.5.tgz#c8da5064095d48f9e2cfc68f714c9d22e0316fba"
+  integrity sha512-ceLIYRXfwlF3MB6yY6rdYmG9Uq1PgxzYuPDMuQkkmgiuZRiVhhkQsS+sM2hnXDQ6YHHXdBL/9tlhFTH4APfQXw==
   dependencies:
     "@microsoft/tsdoc" "^0.12.21"
     prettier "^2.1.1"


### PR DESCRIPTION
### Changelog
- Update `remark-typescript-tools` to v1.0.5
- Update `provides/invalidates` examples as per the updated signature
- Update all `provides` examples that provide a specific Id to do so via the `arg` if available, regardless of result
- Add docblocks for query hook options
- Add docblocks for builder query/mutation methods & their options
- Use doclinks on the `createApi` page for parameter summaries & examples
- Fix a couple of instances of incorrect doclinks/formatting