### PR TITLE
last-minute renames

### DIFF
--- a/docs/api/createApi.md
+++ b/docs/api/createApi.md
@@ -15,8 +15,8 @@ The main point where you will define a service to use in your application.
 
 ```ts no-transpile
   baseQuery(args: InternalQueryArgs, api: QueryApi): any;
-  endpoints(build: EndpointBuilder<InternalQueryArgs, EntityTypes>): Definitions;
-  entityTypes?: readonly EntityTypes[];
+  endpoints(build: EndpointBuilder<InternalQueryArgs, TagTypes>): Definitions;
+  tagTypes?: readonly TagTypes[];
   reducerPath?: ReducerPath;
   serializeQueryArgs?: SerializeQueryArgs<InternalQueryArgs>;
   keepUnusedDataFor?: number; // value is in seconds
@@ -31,9 +31,9 @@ The main point where you will define a service to use in your application.
 
 [examples](docblock://createApi.ts?token=CreateApiOptions.baseQuery)
 
-### `entityTypes`
+### `tagTypes`
 
-[summary](docblock://createApi.ts?token=CreateApiOptions.entityTypes)
+[summary](docblock://createApi.ts?token=CreateApiOptions.tagTypes)
 
 ### `reducerPath`
 

--- a/docs/api/created-api/code-splitting.md
+++ b/docs/api/created-api/code-splitting.md
@@ -44,14 +44,14 @@ This method is primarily useful for code splitting and hot reloading.
 const enhanceEndpoints = (endpointOptions: EnhanceEndpointsOptions) => EnhancedApiSlice;
 
 interface EnhanceEndpointsOptions {
-  addEntityTypes?: readonly string[];
+  addTagTypes?: readonly string[];
   endpoints?: Record<string, Partial<EndpointDefinition>>;
 }
 ```
 
 #### Description
 
-Any provided entity types or endpoint definitions will be merged into the existing endpoint definitions for this API slice. Unlike `injectEndpoints`, the partial endpoint definitions will not _replace_ existing definitions, but are rather merged together on a per-definition basis (ie, `Object.assign(existingEndpoint, newPartialEndpoint)`).
+Any provided tag types or endpoint definitions will be merged into the existing endpoint definitions for this API slice. Unlike `injectEndpoints`, the partial endpoint definitions will not _replace_ existing definitions, but are rather merged together on a per-definition basis (ie, `Object.assign(existingEndpoint, newPartialEndpoint)`).
 
 Returns an updated and enhanced version of the API slice object, containing the combined endpoint definitions.
 

--- a/docs/concepts/code-generation.md
+++ b/docs/concepts/code-generation.md
@@ -24,7 +24,7 @@ We recommend placing these generated types in one file that you do not modify (s
 import { api as generatedApi } from './petstore-api.generated';
 
 export const api = generatedApi.enhanceEndpoints({
-  addEntityTypes: ['Pet'],
+  addTagTypes: ['Pet'],
   endpoints: {
     // basic notation: just specify properties to be overridden
     getPetById: {

--- a/docs/concepts/code-generation.md
+++ b/docs/concepts/code-generation.md
@@ -28,10 +28,10 @@ export const api = generatedApi.enhanceEndpoints({
   endpoints: {
     // basic notation: just specify properties to be overridden
     getPetById: {
-      provides: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
+      providesTags: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
     findPetsByStatus: {
-      provides: (result) =>
+      providesTags: (result) =>
         // is result available?
         result
           ? // successful query
@@ -41,13 +41,13 @@ export const api = generatedApi.enhanceEndpoints({
     },
     // alternate notation: callback that gets passed in `endpoint` - you can freely modify the object here
     addPet: (endpoint) => {
-      endpoint.invalidates = (result) => [{ type: 'Pet', id: result.id }];
+      endpoint.invalidatesTags = (result) => [{ type: 'Pet', id: result.id }];
     },
     updatePet: {
-      invalidates: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
+      invalidatesTags: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
     deletePet: {
-      invalidates: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
+      invalidatesTags: (result, error, arg) => [{ type: 'Pet', id: arg.petId }],
     },
   },
 });

--- a/docs/concepts/customizing-create-api.md
+++ b/docs/concepts/customizing-create-api.md
@@ -45,7 +45,7 @@ declare module '@rtk-incubator/rtk-query' {
     BaseQuery extends BaseQueryFn,
     Definitions extends EndpointDefinitions,
     ReducerPath extends string,
-    EntityTypes extends string
+    TagTypes extends string
   > {
     [customModuleName]: {
       endpoints: {

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -41,13 +41,13 @@ Notice the `onStart`, `onSuccess`, `onError` methods? Be sure to check out how t
 export type MutationDefinition<
   QueryArg,
   BaseQuery extends BaseQueryFn,
-  EntityTypes extends string,
+  TagTypes extends string,
   ResultType,
   ReducerPath extends string = string,
   Context = Record<string, any>
 > = BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> & {
   type: DefinitionType.mutation;
-  invalidates?: ResultDescription<EntityTypes, ResultType, QueryArg>;
+  invalidates?: ResultDescription<TagTypes, ResultType, QueryArg>;
   provides?: never;
   onStart?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>): void;
   onError?(
@@ -118,17 +118,17 @@ export const PostDetail = () => {
 
 In the real world, it's very common that a developer would want to resync their local data cache with the server after performing a mutation (aka "revalidation"). RTK Query takes a more centralized approach to this and requires you to configure the invalidation behavior in your API service definition. Before getting started, let's cover some new terms used when defining an endpoint in a service:
 
-#### Entities
+#### Tags
 
-For RTK Query, _entities_ are just a name that you can give to a specific collection of data to control caching and invalidation behavior, and are defined in an `entityTypes` argument. For example, in an application that has both `Posts` and `Users`, you would define `entityTypes: ['Posts', 'Users']` when calling `createApi`.
+For RTK Query, _tags_ are just a name that you can give to a specific collection of data to control caching and invalidation behavior, and are defined in an `tagTypes` argument. For example, in an application that has both `Posts` and `Users`, you would define `tagTypes: ['Posts', 'Users']` when calling `createApi`.
 
 #### Provides
 
-A _query_ can _provide_ entities to the cache. The `provides` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the query was successful or not.
+A _query_ can _provide_ tags to the cache. The `provides` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the query was successful or not.
 
 #### Invalidates
 
-A _mutation_ can _invalidate_ specific entities in the cache. The `invalidates` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the mutation was successful or not.
+A _mutation_ can _invalidate_ specific tags in the cache. The `invalidates` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the mutation was successful or not.
 
 ### Scenarios and Behaviors
 
@@ -139,7 +139,7 @@ RTK Query provides _a lot_ of flexibility for how you can manage the invalidatio
 ```ts title="API Definition"
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  entityTypes: ['Posts'],
+  tagTypes: ['Posts'],
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
@@ -182,7 +182,7 @@ function App() {
 
 **What to expect**
 
-When `addPost` is triggered, it would cause each `PostDetail` component to go back into a `isFetching` state because `addPost` invalidates the root entity, which causes _every query_ that provides 'Posts' to be re-run. In most cases, this may not be what you want to do. Imagine if you had 100 posts on the screen that all subscribed to a `getPost` query – in this case, you'd create 100 requests and send a ton of unnecessary traffic to your server, which we're trying to avoid in the first place! Even though the user would still see the last good cached result and potentially not notice anything other than their browser hiccuping, you still want to avoid this.
+When `addPost` is triggered, it would cause each `PostDetail` component to go back into a `isFetching` state because `addPost` invalidates the root tag, which causes _every query_ that provides 'Posts' to be re-run. In most cases, this may not be what you want to do. Imagine if you had 100 posts on the screen that all subscribed to a `getPost` query – in this case, you'd create 100 requests and send a ton of unnecessary traffic to your server, which we're trying to avoid in the first place! Even though the user would still see the last good cached result and potentially not notice anything other than their browser hiccuping, you still want to avoid this.
 
 #### Selectively invalidating lists
 
@@ -191,7 +191,7 @@ Keep an eye on the `provides` property of `getPosts` - we'll explain why after.
 ```ts title="API Definition"
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  entityTypes: ['Posts'],
+  tagTypes: ['Posts'],
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
@@ -223,9 +223,9 @@ export const { useGetPostsQuery, useAddPostMutation, useGetPostQuery } = api;
 > **Note about 'LIST' and `id`s**
 >
 > 1. `LIST` is an arbitrary string - technically speaking, you could use anything you want here, such as `ALL` or `*`. The important thing when choosing a custom id is to make sure there is no possibility of it colliding with an id that is returned by a query result. If you have unknown ids in your query results and don't want to risk it, you can go with point 3 below.
-> 2. You can add _many_ entity types for even more control
+> 2. You can add _many_ tag types for even more control
 >    - `[{ type: 'Posts', id: 'LIST' }, { type: 'Posts', id: 'SVELTE_POSTS' }, { type: 'Posts', id: 'REACT_POSTS' }]`
-> 3. If the concept of using an `id` like 'LIST' seems strange to you, you can always add another `entityType` and invalidate it's root, but we recommend using the `id` approach as shown.
+> 3. If the concept of using an `id` like 'LIST' seems strange to you, you can always add another `tagType` and invalidate it's root, but we recommend using the `id` approach as shown.
 
 ```ts title="App.tsx"
 function App() {
@@ -265,12 +265,12 @@ type PostsResponse = Post[];
 export const postApi = createApi({
   reducerPath: 'postsApi',
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  entityTypes: ['Posts'],
+  tagTypes: ['Posts'],
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
       // Provides a list of `Posts` by `id`.
-      // If any mutation is executed that `invalidate`s any of these entities, this query will re-run to be always up-to-date.
+      // If any mutation is executed that `invalidate`s any of these tags, this query will re-run to be always up-to-date.
       // The `LIST` id is a "virtual id" we just made up to be able to invalidate this query specifically if a new `Posts` element was added.
       provides: (result) =>
         // is result available?

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -47,8 +47,8 @@ export type MutationDefinition<
   Context = Record<string, any>
 > = BaseEndpointDefinition<QueryArg, BaseQuery, ResultType> & {
   type: DefinitionType.mutation;
-  invalidates?: ResultDescription<TagTypes, ResultType, QueryArg>;
-  provides?: never;
+  invalidatesTags?: ResultDescription<TagTypes, ResultType, QueryArg>;
+  providesTags?: never;
   onStart?(arg: QueryArg, mutationApi: MutationApi<ReducerPath, Context>): void;
   onError?(
     arg: QueryArg,
@@ -124,11 +124,11 @@ For RTK Query, _tags_ are just a name that you can give to a specific collection
 
 #### Provides
 
-A _query_ can _provide_ tags to the cache. The `provides` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the query was successful or not.
+A _query_ can _provide_ tags to the cache. The `providesTags` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the query was successful or not.
 
 #### Invalidates
 
-A _mutation_ can _invalidate_ specific tags in the cache. The `invalidates` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the mutation was successful or not.
+A _mutation_ can _invalidate_ specific tags in the cache. The `invalidatesTags` argument can either be an array of `string` (such as `['Posts']`), `{type: string, id?: string|number}` or a callback that returns such an array. That function will be passed the result as the first argument, the response error as the second argument, and the argument originally passed into the `query` method as the third argument. Note that either the result or error arguments may be undefined based on whether the mutation was successful or not.
 
 ### Scenarios and Behaviors
 

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -25,7 +25,7 @@ const api = createApi({
       // `result` is the server response
       onSuccess({ id }, mutationApi, result) {},
       onError({ id }, { dispatch, getState, extra, requestId, context }) {},
-      invalidates: ['Post'],
+      invalidatesTags: ['Post'],
     }),
   }),
 });
@@ -143,7 +143,7 @@ export const api = createApi({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : ['Posts']),
+      providesTags: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : ['Posts']),
     }),
     addPost: build.mutation<Post, Partial<Post>>({
       query: (body) => ({
@@ -151,11 +151,11 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
-      invalidates: ['Posts'],
+      invalidatesTags: ['Posts'],
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => [{ type: 'Posts', id }],
+      providesTags: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });
@@ -195,7 +195,7 @@ export const api = createApi({
   endpoints: (build) => ({
     getPosts: build.query<PostsResponse, void>({
       query: () => 'posts',
-      provides: (result) =>
+      providesTags: (result) =>
         result
           ? [...result.map(({ id }) => ({ type: 'Posts', id })), { type: 'Posts', id: 'LIST' }]
           : [{ type: 'Posts', id: 'LIST' }],
@@ -208,11 +208,11 @@ export const api = createApi({
           body,
         };
       },
-      invalidates: [{ type: 'Posts', id: 'LIST' }],
+      invalidatesTags: [{ type: 'Posts', id: 'LIST' }],
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => [{ type: 'Posts', id }],
+      providesTags: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });
@@ -272,7 +272,7 @@ export const postApi = createApi({
       // Provides a list of `Posts` by `id`.
       // If any mutation is executed that `invalidate`s any of these tags, this query will re-run to be always up-to-date.
       // The `LIST` id is a "virtual id" we just made up to be able to invalidate this query specifically if a new `Posts` element was added.
-      provides: (result) =>
+      providesTags: (result) =>
         // is result available?
         result
           ? // successful query
@@ -290,11 +290,11 @@ export const postApi = createApi({
       },
       // Invalidates all Post-type queries providing the `LIST` id - after all, depending of the sort order,
       // that newly created post could show up in any lists.
-      invalidates: [{ type: 'Posts', id: 'LIST' }],
+      invalidatesTags: [{ type: 'Posts', id: 'LIST' }],
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,
-      provides: (result, error, id) => [{ type: 'Posts', id }],
+      providesTags: (result, error, id) => [{ type: 'Posts', id }],
     }),
     updatePost: build.mutation<Post, Partial<Post>>({
       query(data) {
@@ -307,7 +307,7 @@ export const postApi = createApi({
       },
       // Invalidates all queries that subscribe to this Post `id` only.
       // In this case, `getPost` will be re-run. `getPosts` *might*  rerun, if this id was under it's results.
-      invalidates: (result, error, { id }) => [{ type: 'Posts', id }],
+      invalidatesTags: (result, error, { id }) => [{ type: 'Posts', id }],
     }),
     deletePost: build.mutation<{ success: boolean; id: number }, number>({
       query(id) {
@@ -317,7 +317,7 @@ export const postApi = createApi({
         };
       },
       // Invalidates all queries that subscribe to this Post `id` only.
-      invalidates: (result, error, id) => [{ type: 'Posts', id }],
+      invalidatesTags: (result, error, id) => [{ type: 'Posts', id }],
     }),
   }),
 });

--- a/docs/concepts/optimistic-updates.md
+++ b/docs/concepts/optimistic-updates.md
@@ -19,7 +19,7 @@ const api = createApi({
   baseQuery,
   tagTypes: ['Post'],
   endpoints: (build) => ({
-    getPost: build.query<Post, string>({ query: (id) => `post/${id}`, provides: ['Post'] }),
+    getPost: build.query<Post, string>({ query: (id) => `post/${id}`, providesTags: ['Post'] }),
     updatePost: build.mutation<void, Pick<Post, 'id'> & Partial<Post>, { undoPost: Patch[] }>({
       query: ({ id, ...patch }) => ({ url: `post/${id}`, method: 'PATCH', body: patch }),
       onStart({ id, ...patch }, { dispatch, context }) {
@@ -34,7 +34,7 @@ const api = createApi({
         // If there is an error, roll it back
         dispatch(api.util.patchQueryResult('getPost', id, context.undoPost));
       },
-      invalidates: ['Post'],
+      invalidatesTags: ['Post'],
     }),
   }),
 });

--- a/docs/concepts/optimistic-updates.md
+++ b/docs/concepts/optimistic-updates.md
@@ -17,7 +17,7 @@ The core concepts are:
 ```ts title="Example optimistic update mutation"
 const api = createApi({
   baseQuery,
-  entityTypes: ['Post'],
+  tagTypes: ['Post'],
   endpoints: (build) => ({
     getPost: build.query<Post, string>({ query: (id) => `post/${id}`, provides: ['Post'] }),
     updatePost: build.mutation<void, Pick<Post, 'id'> & Partial<Post>, { undoPost: Patch[] }>({

--- a/docs/concepts/prefetching.md
+++ b/docs/concepts/prefetching.md
@@ -84,7 +84,7 @@ export function usePrefetchImmediately<T extends EndpointNames>(
 ) {
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(api.util.prefetchThunk(endpoint, arg, options));
+    dispatch(api.util.prefetch(endpoint, arg, options));
   }, []);
 }
 
@@ -96,10 +96,10 @@ usePrefetchImmediately('getUser', 5);
 
 If you're not using the `usePrefetch` hook, you can recreate the same behavior easily on your own in any framework.
 
-When dispatching the `prefetchThunk` as shown below you will see the same exact behavior as [described here](#what-to-expect-when-you-call-the-callback).
+When dispatching the `prefetch` thunk as shown below you will see the same exact behavior as [described here](#what-to-expect-when-you-call-the-callback).
 
 ```js title="Non-hook prefetching example"
-store.dispatch(api.util.prefetchThunk(endpointName, arg, { force: false, ifOlderThan: 10 }));
+store.dispatch(api.util.prefetch(endpointName, arg, { force: false, ifOlderThan: 10 }));
 ```
 
 You can also dispatch the query action, but you would be responsible for implementing any additional logic.

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -26,7 +26,7 @@ const api = createApi({
       // `result` is the server response
       onSuccess(id, queryApi, result) {},
       onError(id, queryApi) {},
-      provides: (result, error, id) => [{ type: 'Post', id }],
+      providesTags: (result, error, id) => [{ type: 'Post', id }],
     }),
   }),
 });

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -1,4 +1,4 @@
-import { EndpointDefinitions, EndpointBuilder, EndpointDefinition, ReplaceEntityTypes } from './endpointDefinitions';
+import { EndpointDefinitions, EndpointBuilder, EndpointDefinition, ReplaceTagTypes } from './endpointDefinitions';
 import { UnionToIntersection, Id, NoInfer } from './tsHelpers';
 import { CoreModule } from './core/module';
 import { CreateApiOptions } from './createApi';
@@ -12,7 +12,7 @@ export interface ApiModules<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   ReducerPath extends string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  EntityTypes extends string
+  TagTypes extends string
 > {}
 
 export type ModuleName = keyof ApiModules<any, any, any, any>;
@@ -23,10 +23,10 @@ export type Module<Name extends ModuleName> = {
     BaseQuery extends BaseQueryFn,
     Definitions extends EndpointDefinitions,
     ReducerPath extends string,
-    EntityTypes extends string
+    TagTypes extends string
   >(
-    api: Api<BaseQuery, EndpointDefinitions, ReducerPath, EntityTypes, ModuleName>,
-    options: Required<CreateApiOptions<BaseQuery, Definitions, ReducerPath, EntityTypes>>,
+    api: Api<BaseQuery, EndpointDefinitions, ReducerPath, TagTypes, ModuleName>,
+    options: Required<CreateApiOptions<BaseQuery, Definitions, ReducerPath, TagTypes>>,
     context: ApiContext<Definitions>
   ): {
     injectEndpoint(endpointName: string, definition: EndpointDefinition<any, any, any, any>): void;
@@ -42,32 +42,34 @@ export type Api<
   BaseQuery extends BaseQueryFn,
   Definitions extends EndpointDefinitions,
   ReducerPath extends string,
-  EntityTypes extends string,
+  TagTypes extends string,
   Enhancers extends ModuleName = CoreModule
 > = Id<
-  Id<UnionToIntersection<ApiModules<BaseQuery, Definitions, ReducerPath, EntityTypes>[Enhancers]>> & {
+  Id<UnionToIntersection<ApiModules<BaseQuery, Definitions, ReducerPath, TagTypes>[Enhancers]>> & {
     /**
      * A function to inject the endpoints into the original API, but also give you that same API with correct types for these endpoints back. Useful with code-splitting.
      */
     injectEndpoints<NewDefinitions extends EndpointDefinitions>(_: {
-      endpoints: (build: EndpointBuilder<BaseQuery, EntityTypes, ReducerPath>) => NewDefinitions;
+      endpoints: (build: EndpointBuilder<BaseQuery, TagTypes, ReducerPath>) => NewDefinitions;
       overrideExisting?: boolean;
-    }): Api<BaseQuery, Definitions & NewDefinitions, ReducerPath, EntityTypes, Enhancers>;
+    }): Api<BaseQuery, Definitions & NewDefinitions, ReducerPath, TagTypes, Enhancers>;
     /**
      *A function to enhance a generated API with additional information. Useful with code-generation.
      */
-    enhanceEndpoints<NewEntityTypes extends string = never>(_: {
-      addEntityTypes?: readonly NewEntityTypes[];
-      endpoints?: ReplaceEntityTypes<Definitions, EntityTypes | NoInfer<NewEntityTypes>> extends infer NewDefinitions
+    enhanceEndpoints<NewTagTypes extends string = never>(_: {
+      /** @deprecated */
+      addEntityTypes?: readonly NewTagTypes[];
+      addTagTypes?: readonly NewTagTypes[];
+      endpoints?: ReplaceTagTypes<Definitions, TagTypes | NoInfer<NewTagTypes>> extends infer NewDefinitions
         ? {
             [K in keyof NewDefinitions]?: Partial<NewDefinitions[K]> | ((definition: NewDefinitions[K]) => void);
           }
         : never;
     }): Api<
       BaseQuery,
-      ReplaceEntityTypes<Definitions, EntityTypes | NewEntityTypes>,
+      ReplaceTagTypes<Definitions, TagTypes | NewTagTypes>,
       ReducerPath,
-      EntityTypes | NewEntityTypes,
+      TagTypes | NewTagTypes,
       Enhancers
     >;
   }

--- a/src/core/apiState.ts
+++ b/src/core/apiState.ts
@@ -194,8 +194,8 @@ export type CombinedState<D extends EndpointDefinitions, E extends string, Reduc
   config: ConfigState<ReducerPath>;
 };
 
-export type InvalidationState<EntityTypes extends string> = {
-  [_ in EntityTypes]: {
+export type InvalidationState<TagTypes extends string> = {
+  [_ in TagTypes]: {
     [id: string]: Array<QueryCacheKey>;
     [id: number]: Array<QueryCacheKey>;
   };
@@ -223,10 +223,6 @@ export type MutationState<D extends EndpointDefinitions> = {
   [requestId: string]: MutationSubState<D[string]> | undefined;
 };
 
-export type RootState<
-  Definitions extends EndpointDefinitions,
-  EntityTypes extends string,
-  ReducerPath extends string
-> = {
-  [P in ReducerPath]: CombinedState<Definitions, EntityTypes, P>;
+export type RootState<Definitions extends EndpointDefinitions, TagTypes extends string, ReducerPath extends string> = {
+  [P in ReducerPath]: CombinedState<Definitions, TagTypes, P>;
 };

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -12,12 +12,7 @@ import {
 import { QueryCacheKey, QueryStatus, QuerySubState, QuerySubstateIdentifier, RootState, Subscribers } from './apiState';
 import { Api, ApiContext } from '../apiTypes';
 import { calculateProvidedByThunk, MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks';
-import {
-  AssertEntityTypes,
-  calculateProvidedBy,
-  EndpointDefinitions,
-  FullEntityDescription,
-} from '../endpointDefinitions';
+import { AssertTagTypes, calculateProvidedBy, EndpointDefinitions, FullTagDescription } from '../endpointDefinitions';
 import { onFocus, onOnline } from './setupListeners';
 import { flatten } from '../utils';
 
@@ -27,7 +22,7 @@ type TimeoutId = ReturnType<typeof setTimeout>;
 export function buildMiddleware<
   Definitions extends EndpointDefinitions,
   ReducerPath extends string,
-  EntityTypes extends string
+  TagTypes extends string
 >({
   reducerPath,
   context,
@@ -35,14 +30,14 @@ export function buildMiddleware<
   queryThunk,
   mutationThunk,
   api,
-  assertEntityType,
+  assertTagType,
 }: {
   reducerPath: ReducerPath;
   context: ApiContext<Definitions>;
   queryThunk: AsyncThunk<ThunkResult, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<ThunkResult, MutationThunkArg<any>, {}>;
-  api: Api<any, EndpointDefinitions, ReducerPath, EntityTypes>;
-  assertEntityType: AssertEntityTypes;
+  api: Api<any, EndpointDefinitions, ReducerPath, TagTypes>;
+  assertTagType: AssertTagTypes;
 }) {
   type MWApi = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerPath>>;
   const { removeQueryResult, unsubscribeQueryResult, updateSubscriptionOptions, resetApiState } = api.internalActions;
@@ -51,9 +46,7 @@ export function buildMiddleware<
   const currentPolls: QueryStateMeta<{ nextPollTimestamp: number; timeout?: TimeoutId; pollingInterval: number }> = {};
 
   const actions = {
-    invalidateEntities: createAction<Array<EntityTypes | FullEntityDescription<EntityTypes>>>(
-      `${reducerPath}/invalidateEntities`
-    ),
+    invalidateTags: createAction<Array<TagTypes | FullTagDescription<TagTypes>>>(`${reducerPath}/invalidateTags`),
   };
 
   const middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>> = (
@@ -62,11 +55,11 @@ export function buildMiddleware<
     const result = next(action);
 
     if (isAnyOf(isFulfilled(mutationThunk), isRejectedWithValue(mutationThunk))(action)) {
-      invalidateEntities(calculateProvidedByThunk(action, 'invalidates', endpointDefinitions, assertEntityType), mwApi);
+      invalidateTags(calculateProvidedByThunk(action, 'invalidates', endpointDefinitions, assertTagType), mwApi);
     }
 
-    if (actions.invalidateEntities.match(action)) {
-      invalidateEntities(calculateProvidedBy(action.payload, undefined, undefined, undefined, assertEntityType), mwApi);
+    if (actions.invalidateTags.match(action)) {
+      invalidateTags(calculateProvidedBy(action.payload, undefined, undefined, undefined, assertTagType), mwApi);
     }
 
     if (unsubscribeQueryResult.match(action)) {
@@ -145,20 +138,20 @@ export function buildMiddleware<
     });
   }
 
-  function invalidateEntities(entities: readonly FullEntityDescription<string>[], api: MWApi) {
+  function invalidateTags(tags: readonly FullTagDescription<string>[], api: MWApi) {
     const state = api.getState()[reducerPath];
 
     const toInvalidate = new Set<QueryCacheKey>();
-    for (const entity of entities) {
-      const provided = state.provided[entity.type];
+    for (const tag of tags) {
+      const provided = state.provided[tag.type];
       if (!provided) {
         continue;
       }
 
       let invalidateSubscriptions =
-        (entity.id !== undefined
+        (tag.id !== undefined
           ? // id given: invalidate all queries that provide this type & id
-            provided[entity.id]
+            provided[tag.id]
           : // no id: invalidate all queries that provide this type
             flatten(Object.values(provided))) ?? [];
 

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -55,7 +55,7 @@ export function buildMiddleware<
     const result = next(action);
 
     if (isAnyOf(isFulfilled(mutationThunk), isRejectedWithValue(mutationThunk))(action)) {
-      invalidateTags(calculateProvidedByThunk(action, 'invalidates', endpointDefinitions, assertTagType), mwApi);
+      invalidateTags(calculateProvidedByThunk(action, 'invalidatesTags', endpointDefinitions, assertTagType), mwApi);
     }
 
     if (actions.invalidateTags.match(action)) {

--- a/src/core/buildSelectors.ts
+++ b/src/core/buildSelectors.ts
@@ -12,7 +12,7 @@ import {
   QueryDefinition,
   MutationDefinition,
   QueryArgFrom,
-  EntityTypesFrom,
+  TagTypesFrom,
   ReducerPathFrom,
 } from '../endpointDefinitions';
 import { InternalSerializeQueryArgs } from '../defaultSerializeQueryArgs';
@@ -26,7 +26,7 @@ declare module './module' {
   > {
     select: QueryResultSelectorFactory<
       Definition,
-      _RootState<Definitions, EntityTypesFrom<Definition>, ReducerPathFrom<Definition>>
+      _RootState<Definitions, TagTypesFrom<Definition>, ReducerPathFrom<Definition>>
     >;
   }
 
@@ -36,7 +36,7 @@ declare module './module' {
   > {
     select: MutationResultSelectorFactory<
       Definition,
-      _RootState<Definitions, EntityTypesFrom<Definition>, ReducerPathFrom<Definition>>
+      _RootState<Definitions, TagTypesFrom<Definition>, ReducerPathFrom<Definition>>
     >;
   }
 }

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -24,7 +24,7 @@ import {
   ConfigState,
 } from './apiState';
 import { calculateProvidedByThunk, MutationThunkArg, QueryThunkArg, ThunkResult } from './buildThunks';
-import { AssertEntityTypes, EndpointDefinitions } from '../endpointDefinitions';
+import { AssertTagTypes, EndpointDefinitions } from '../endpointDefinitions';
 import { applyPatches, Patch } from 'immer';
 import { onFocus, onFocusLost, onOffline, onOnline } from './setupListeners';
 import { isDocumentVisible, isOnline, copyWithStructuralSharing } from '../utils';
@@ -59,14 +59,14 @@ export function buildSlice({
   queryThunk,
   mutationThunk,
   context: { endpointDefinitions: definitions },
-  assertEntityType,
+  assertTagType,
   config,
 }: {
   reducerPath: string;
   queryThunk: AsyncThunk<ThunkResult, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<ThunkResult, MutationThunkArg<any>, {}>;
   context: ApiContext<EndpointDefinitions>;
-  assertEntityType: AssertEntityTypes;
+  assertTagType: AssertTagTypes;
   config: Omit<ConfigState<string>, 'online' | 'focused'>;
 }) {
   const resetApiState = createAction(`${reducerPath}/resetApiState`);
@@ -176,8 +176,8 @@ export function buildSlice({
     extraReducers(builder) {
       builder
         .addCase(querySlice.actions.removeQueryResult, (draft, { payload: { queryCacheKey } }) => {
-          for (const entityTypeSubscriptions of Object.values(draft)) {
-            for (const idSubscriptions of Object.values(entityTypeSubscriptions)) {
+          for (const tagTypeSubscriptions of Object.values(draft)) {
+            for (const idSubscriptions of Object.values(tagTypeSubscriptions)) {
               const foundAt = idSubscriptions.indexOf(queryCacheKey);
               if (foundAt !== -1) {
                 idSubscriptions.splice(foundAt, 1);
@@ -186,10 +186,10 @@ export function buildSlice({
           }
         })
         .addMatcher(isAnyOf(isFulfilled(queryThunk), isRejectedWithValue(queryThunk)), (draft, action) => {
-          const providedEntities = calculateProvidedByThunk(action, 'provides', definitions, assertEntityType);
+          const providedTags = calculateProvidedByThunk(action, 'provides', definitions, assertTagType);
           const { queryCacheKey } = action.meta.arg;
 
-          for (const { type, id } of providedEntities) {
+          for (const { type, id } of providedTags) {
             const subscribedQueries = ((draft[type] ??= {})[id || '__internal_without_id'] ??= []);
             const alreadySubscribed = subscribedQueries.includes(queryCacheKey);
             if (!alreadySubscribed) {

--- a/src/core/buildSlice.ts
+++ b/src/core/buildSlice.ts
@@ -186,7 +186,7 @@ export function buildSlice({
           }
         })
         .addMatcher(isAnyOf(isFulfilled(queryThunk), isRejectedWithValue(queryThunk)), (draft, action) => {
-          const providedTags = calculateProvidedByThunk(action, 'provides', definitions, assertTagType);
+          const providedTags = calculateProvidedByThunk(action, 'providesTags', definitions, assertTagType);
           const { queryCacheKey } = action.meta.arg;
 
           for (const { type, id } of providedTags) {

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -294,7 +294,7 @@ export function buildThunks<
   const hasTheForce = (options: any): options is { force: boolean } => 'force' in options;
   const hasMaxAge = (options: any): options is { ifOlderThan: false | number } => 'ifOlderThan' in options;
 
-  const prefetchThunk = <EndpointName extends QueryKeys<EndpointDefinitions>>(
+  const prefetch = <EndpointName extends QueryKeys<EndpointDefinitions>>(
     endpointName: EndpointName,
     arg: any,
     options: PrefetchOptions
@@ -338,7 +338,7 @@ export function buildThunks<
     } as Matchers<Thunk, any>;
   }
 
-  return { queryThunk, mutationThunk, prefetchThunk, updateQueryResult, patchQueryResult, buildMatchThunkActions };
+  return { queryThunk, mutationThunk, prefetch, updateQueryResult, patchQueryResult, buildMatchThunkActions };
 }
 
 export function calculateProvidedByThunk(

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -4,7 +4,7 @@ import { BaseQueryFn, BaseQueryArg, BaseQueryError, QueryReturnValue } from '../
 import { RootState, QueryKeys, QueryStatus, QuerySubstateIdentifier } from './apiState';
 import { StartQueryActionCreatorOptions } from './buildInitiate';
 import {
-  AssertEntityTypes,
+  AssertTagTypes,
   calculateProvidedBy,
   EndpointDefinition,
   EndpointDefinitions,
@@ -345,13 +345,13 @@ export function calculateProvidedByThunk(
   action: UnwrapPromise<ReturnType<ReturnType<QueryThunk>> | ReturnType<ReturnType<MutationThunk>>>,
   type: 'provides' | 'invalidates',
   endpointDefinitions: EndpointDefinitions,
-  assertEntityType: AssertEntityTypes
+  assertTagType: AssertTagTypes
 ) {
   return calculateProvidedBy(
     endpointDefinitions[action.meta.arg.endpointName][type],
     isFulfilled(action) ? action.payload.result : undefined,
     isRejectedWithValue(action) ? action.payload : undefined,
     action.meta.arg.originalArgs,
-    assertEntityType
+    assertTagType
   );
 }

--- a/src/core/buildThunks.ts
+++ b/src/core/buildThunks.ts
@@ -343,7 +343,7 @@ export function buildThunks<
 
 export function calculateProvidedByThunk(
   action: UnwrapPromise<ReturnType<ReturnType<QueryThunk>> | ReturnType<ReturnType<MutationThunk>>>,
-  type: 'provides' | 'invalidates',
+  type: 'providesTags' | 'invalidatesTags',
   endpointDefinitions: EndpointDefinitions,
   assertTagType: AssertTagTypes
 ) {

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -105,6 +105,12 @@ declare module '../apiTypes' {
         /**
          * TODO
          */
+        prefetch<EndpointName extends QueryKeys<EndpointDefinitions>>(
+          endpointName: EndpointName,
+          arg: QueryArgFrom<Definitions[EndpointName]>,
+          options: PrefetchOptions
+        ): ThunkAction<void, any, any, AnyAction>;
+        /* @deprecated */
         prefetchThunk<EndpointName extends QueryKeys<EndpointDefinitions>>(
           endpointName: EndpointName,
           arg: QueryArgFrom<Definitions[EndpointName]>,
@@ -227,7 +233,7 @@ export const coreModule = (): Module<CoreModule> => ({
       mutationThunk,
       patchQueryResult,
       updateQueryResult,
-      prefetchThunk,
+      prefetch,
       buildMatchThunkActions,
     } = buildThunks({
       baseQuery,
@@ -249,7 +255,7 @@ export const coreModule = (): Module<CoreModule> => ({
     safeAssign(api.util, {
       patchQueryResult,
       updateQueryResult,
-      prefetchThunk,
+      prefetch,
       resetApiState: sliceActions.resetApiState,
     });
     safeAssign(api.internalActions, sliceActions);
@@ -287,6 +293,16 @@ export const coreModule = (): Module<CoreModule> => ({
           );
         }
         return api.util.invalidateTags;
+      },
+    });
+    Object.defineProperty(api.util, 'prefetchThunk', {
+      get() {
+        if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
+          console.warn(
+            '`api.util.prefetchThunk` has been renamed to `api.util.prefetch`, please change your code accordingly'
+          );
+        }
+        return api.util.prefetch;
       },
     });
 

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -202,6 +202,22 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
               partialDefinition(context.endpointDefinitions[endpointName]);
             }
             Object.assign(context.endpointDefinitions[endpointName] || {}, partialDefinition);
+            // remove in final release
+            const x = context.endpointDefinitions[endpointName];
+            if (x?.provides) {
+              if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
+                console.warn('`provides` has been renamed to `providesTags`, please change your code accordingly');
+              }
+              x.providesTags = x.provides;
+            }
+            if (x?.invalidates) {
+              if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
+                console.warn(
+                  '`invalidates` has been renamed to `invalidatesTags`, please change your code accordingly'
+                );
+              }
+              x.invalidatesTags = x.invalidates;
+            }
           }
         }
         return api;

--- a/src/createApi.ts
+++ b/src/createApi.ts
@@ -212,8 +212,26 @@ export function buildCreateApi<Modules extends [Module<any>, ...Module<any>[]]>(
 
     function injectEndpoints(inject: Parameters<typeof api.injectEndpoints>[0]) {
       const evaluatedEndpoints = inject.endpoints({
-        query: (x) => ({ ...x, type: DefinitionType.query } as any),
-        mutation: (x) => ({ ...x, type: DefinitionType.mutation } as any),
+        query: (x) => {
+          // remove in final release
+          if (x.provides) {
+            if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
+              console.warn('`provides` has been renamed to `providesTags`, please change your code accordingly');
+            }
+            x.providesTags ??= x.provides;
+          }
+          return { ...x, type: DefinitionType.query } as any;
+        },
+        mutation: (x) => {
+          // remove in final release
+          if (x.invalidates) {
+            if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
+              console.warn('`invalidates` has been renamed to `invalidatesTags`, please change your code accordingly');
+            }
+            x.invalidatesTags ??= x.invalidates;
+          }
+          return { ...x, type: DefinitionType.mutation } as any;
+        },
       });
 
       for (const [endpointName, definition] of Object.entries(evaluatedEndpoints)) {

--- a/src/endpointDefinitions.ts
+++ b/src/endpointDefinitions.ts
@@ -114,10 +114,14 @@ interface QueryExtraOptions<
    *   2.  `[{ type: 'Post' }]` - equivalent to `a`
    *   3.  `[{ type: 'Post', id: 1 }]`
    */
+  providesTags?: ResultDescription<TagTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
+  /** @deprecated renamed to `providesTags` */
   provides?: ResultDescription<TagTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   /**
    * Not to be used. A query should not invalidate tags in the cache.
    */
+  invalidatesTags?: never;
+  /** @deprecated */
   invalidates?: never;
   /**
    * Called when the query is triggered.
@@ -199,10 +203,14 @@ interface MutationExtraOptions<
    * - Used by `mutations` for [cache invalidation](../concepts/mutations#advanced-mutations-with-revalidation) purposes.
    * - Expects the same shapes as `provides`.
    */
+  invalidatesTags?: ResultDescription<TagTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
+  /** @deprecated renamed to `invalidatesTags` */
   invalidates?: ResultDescription<TagTypes, ResultType, QueryArg, BaseQueryError<BaseQuery>>;
   /**
    * Not to be used. A mutation should not provide tags to the cache.
    */
+  providesTags?: never;
+  /** @deprecated */
   provides?: never;
   /**
    * Called when the mutation is triggered.
@@ -289,7 +297,7 @@ export type EndpointBuilder<BaseQuery extends BaseQueryFn, TagTypes extends stri
    *      // `result` is the server response
    *      onSuccess(id, queryApi, result) {},
    *      onError(id, queryApi) {},
-   *      provides: (result, error, id) => [{ type: 'Post', id }],
+   *      providesTags: (result, error, id) => [{ type: 'Post', id }],
    *    }),
    *  }),
    *});
@@ -317,7 +325,7 @@ export type EndpointBuilder<BaseQuery extends BaseQueryFn, TagTypes extends stri
    *       // `result` is the server response
    *       onSuccess({ id }, mutationApi, result) {},
    *       onError({ id }, { dispatch, getState, extra, requestId, context }) {},
-   *       invalidates: (result, error, id) => [{ type: 'Post', id }],
+   *       invalidatesTags: (result, error, id) => [{ type: 'Post', id }],
    *     }),
    *   }),
    * });

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -351,7 +351,7 @@ export function buildHooks<Definitions extends EndpointDefinitions>({
     return useCallback(
       (arg: any, options?: PrefetchOptions) =>
         dispatch(
-          (api.util.prefetchThunk as GenericPrefetchThunk)(endpointName, arg, { ...stableDefaultOptions, ...options })
+          (api.util.prefetch as GenericPrefetchThunk)(endpointName, arg, { ...stableDefaultOptions, ...options })
         ),
       [endpointName, dispatch, stableDefaultOptions]
     );

--- a/src/react-hooks/module.ts
+++ b/src/react-hooks/module.ts
@@ -33,7 +33,7 @@ declare module '../apiTypes' {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ReducerPath extends string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    EntityTypes extends string
+    TagTypes extends string
   > {
     [reactHooksModuleName]: {
       /**

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -857,15 +857,15 @@ describe('hooks tests', () => {
   describe('useQuery and useMutation invalidation behavior', () => {
     const api = createApi({
       baseQuery: fetchBaseQuery({ baseUrl: 'https://example.com' }),
-      entityTypes: ['User'],
+      tagTypes: ['User'],
       endpoints: (build) => ({
         checkSession: build.query<any, void>({
           query: () => '/me',
-          provides: ['User'],
+          providesTags: ['User'],
         }),
         login: build.mutation<any, any>({
           query: () => ({ url: '/login', method: 'POST' }),
-          invalidates: ['User'],
+          invalidatesTags: ['User'],
         }),
       }),
     });
@@ -875,7 +875,7 @@ describe('hooks tests', () => {
         return [...state, action];
       },
     });
-    test('initially failed useQueries that provide an entity will refetch after a mutation invalidates it', async () => {
+    test('initially failed useQueries that provide an tag will refetch after a mutation invalidates it', async () => {
       const checkSessionData = { name: 'matt' };
       server.use(
         rest.get('https://example.com/me', (req, res, ctx) => {
@@ -1093,11 +1093,11 @@ describe('hooks with createApi defaults set', () => {
 
     const api = createApi({
       baseQuery: fetchBaseQuery({ baseUrl: 'http://example.com/' }),
-      entityTypes: ['Posts'],
+      tagTypes: ['Posts'],
       endpoints: (build) => ({
         getPosts: build.query<PostsResponse, void>({
           query: () => ({ url: 'posts' }),
-          provides: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
+          providesTags: (result) => (result ? result.map(({ id }) => ({ type: 'Posts', id })) : []),
         }),
         updatePost: build.mutation<Post, Partial<Post>>({
           query: ({ id, ...body }) => ({
@@ -1105,7 +1105,7 @@ describe('hooks with createApi defaults set', () => {
             method: 'PUT',
             body,
           }),
-          invalidates: (result, error, { id }) => [{ type: 'Posts', id }],
+          invalidatesTags: (result, error, { id }) => [{ type: 'Posts', id }],
         }),
         addPost: build.mutation<Post, Partial<Post>>({
           query: (body) => ({
@@ -1113,7 +1113,7 @@ describe('hooks with createApi defaults set', () => {
             method: 'POST',
             body,
           }),
-          invalidates: ['Posts'],
+          invalidatesTags: ['Posts'],
         }),
       }),
     });

--- a/test/buildMiddleware.test.tsx
+++ b/test/buildMiddleware.test.tsx
@@ -4,19 +4,19 @@ import { actionsReducer, matchSequence, setupApiStore, waitMs } from './helpers'
 const baseQuery = (args?: any) => ({ data: args });
 const api = createApi({
   baseQuery,
-  entityTypes: ['Banana', 'Bread'],
+  tagTypes: ['Banana', 'Bread'],
   endpoints: (build) => ({
     getBanana: build.query<unknown, number>({
       query(id) {
         return { url: `banana/${id}` };
       },
-      provides: ['Banana'],
+      providesTags: ['Banana'],
     }),
     getBread: build.query<unknown, number>({
       query(id) {
         return { url: `bread/${id}` };
       },
-      provides: ['Bread'],
+      providesTags: ['Bread'],
     }),
   }),
 });
@@ -26,11 +26,11 @@ const storeRef = setupApiStore(api, {
   ...actionsReducer,
 });
 
-it('invalidates the specified entities', async () => {
+it('invalidates the specified tags', async () => {
   await storeRef.store.dispatch(getBanana.initiate(1));
   matchSequence(storeRef.store.getState().actions, getBanana.matchPending, getBanana.matchFulfilled);
 
-  await storeRef.store.dispatch(api.util.invalidateEntities(['Banana', 'Bread']));
+  await storeRef.store.dispatch(api.util.invalidateTags(['Banana', 'Bread']));
 
   // Slight pause to let the middleware run and such
   await waitMs(20);
@@ -38,14 +38,14 @@ it('invalidates the specified entities', async () => {
   const firstSequence = [
     getBanana.matchPending,
     getBanana.matchFulfilled,
-    api.util.invalidateEntities.match,
+    api.util.invalidateTags.match,
     getBanana.matchPending,
     getBanana.matchFulfilled,
   ];
   matchSequence(storeRef.store.getState().actions, ...firstSequence);
 
   await storeRef.store.dispatch(getBread.initiate(1));
-  await storeRef.store.dispatch(api.util.invalidateEntities([{ type: 'Bread' }]));
+  await storeRef.store.dispatch(api.util.invalidateTags([{ type: 'Bread' }]));
 
   await waitMs(20);
 
@@ -54,29 +54,29 @@ it('invalidates the specified entities', async () => {
     ...firstSequence,
     getBread.matchPending,
     getBread.matchFulfilled,
-    api.util.invalidateEntities.match,
+    api.util.invalidateTags.match,
     getBread.matchPending,
     getBread.matchFulfilled
   );
 });
 
 describe.skip('TS only tests', () => {
-  it('should allow for an array of string EntityTypes', () => {
-    api.util.invalidateEntities(['Banana', 'Bread']);
+  it('should allow for an array of string TagTypes', () => {
+    api.util.invalidateTags(['Banana', 'Bread']);
   });
-  it('should allow for an array of full EntityTypes descriptions', () => {
-    api.util.invalidateEntities([{ type: 'Banana' }, { type: 'Bread', id: 1 }]);
+  it('should allow for an array of full TagTypes descriptions', () => {
+    api.util.invalidateTags([{ type: 'Banana' }, { type: 'Bread', id: 1 }]);
   });
 
   it('should allow for a mix of full descriptions as well as plain strings', () => {
-    api.util.invalidateEntities(['Banana', { type: 'Bread', id: 1 }]);
+    api.util.invalidateTags(['Banana', { type: 'Bread', id: 1 }]);
   });
-  it('should error when using non-existing EntityTypes', () => {
+  it('should error when using non-existing TagTypes', () => {
     // @ts-expect-error
-    api.util.invalidateEntities(['Missing Entity']);
+    api.util.invalidateTags(['Missing Tag']);
   });
-  it('should error when using non-existing EntityTypes in the full format', () => {
+  it('should error when using non-existing TagTypes in the full format', () => {
     // @ts-expect-error
-    api.util.invalidateEntities([{ type: 'Missing' }]);
+    api.util.invalidateTags([{ type: 'Missing' }]);
   });
 });

--- a/test/createApi.test.ts
+++ b/test/createApi.test.ts
@@ -152,7 +152,7 @@ describe('wrong entityTypes log errors', () => {
     } while (result.status === 'pending');
 
     if (shouldError) {
-      expect(spy).toHaveBeenCalledWith("Entity type 'Users' was used, but not specified in `entityTypes`!");
+      expect(spy).toHaveBeenCalledWith("Tag type 'Users' was used, but not specified in `tagTypes`!");
     } else {
       expect(spy).not.toHaveBeenCalled();
     }
@@ -365,7 +365,7 @@ describe('endpoint definition typings', () => {
       storeRef.store.dispatch(api.endpoints.query2.initiate('in2'));
       await waitMs(1);
       debugger;
-      expect(spy).toHaveBeenCalledWith("Entity type 'missing' was used, but not specified in `entityTypes`!");
+      expect(spy).toHaveBeenCalledWith("Tag type 'missing' was used, but not specified in `tagTypes`!");
 
       // only type-test this part
       if (2 > 1) {

--- a/test/createApi.test.ts
+++ b/test/createApi.test.ts
@@ -40,78 +40,78 @@ test('sensible defaults', () => {
   expect(api.reducerPath).toBe('api');
 
   expectType<'api'>(api.reducerPath);
-  type EntityTypes = typeof api extends Api<any, any, any, infer E> ? E : 'no match';
-  expectType<EntityTypes>(ANY as never);
+  type TagTypes = typeof api extends Api<any, any, any, infer E> ? E : 'no match';
+  expectType<TagTypes>(ANY as never);
   // @ts-expect-error
-  expectType<EntityTypes>(0);
+  expectType<TagTypes>(0);
 });
 
-describe('wrong entityTypes log errors', () => {
+describe('wrong tagTypes log errors', () => {
   const baseQuery = jest.fn();
   const api = createApi({
     baseQuery,
-    entityTypes: ['User'],
+    tagTypes: ['User'],
     endpoints: (build) => ({
       provideNothing: build.query<unknown, void>({
         query: () => '',
       }),
       provideTypeString: build.query<unknown, void>({
         query: () => '',
-        provides: ['User'],
+        providesTags: ['User'],
       }),
       provideTypeWithId: build.query<unknown, void>({
         query: () => '',
-        provides: [{ type: 'User', id: 5 }],
+        providesTags: [{ type: 'User', id: 5 }],
       }),
       provideTypeWithIdAndCallback: build.query<unknown, void>({
         query: () => '',
-        provides: () => [{ type: 'User', id: 5 }],
+        providesTags: () => [{ type: 'User', id: 5 }],
       }),
       provideWrongTypeString: build.query<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        provides: ['Users'],
+        providesTags: ['Users'],
       }),
       provideWrongTypeWithId: build.query<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        provides: [{ type: 'Users', id: 5 }],
+        providesTags: [{ type: 'Users', id: 5 }],
       }),
       provideWrongTypeWithIdAndCallback: build.query<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        provides: () => [{ type: 'Users', id: 5 }],
+        providesTags: () => [{ type: 'Users', id: 5 }],
       }),
       invalidateNothing: build.query<unknown, void>({
         query: () => '',
       }),
       invalidateTypeString: build.mutation<unknown, void>({
         query: () => '',
-        invalidates: ['User'],
+        invalidatesTags: ['User'],
       }),
       invalidateTypeWithId: build.mutation<unknown, void>({
         query: () => '',
-        invalidates: [{ type: 'User', id: 5 }],
+        invalidatesTags: [{ type: 'User', id: 5 }],
       }),
       invalidateTypeWithIdAndCallback: build.mutation<unknown, void>({
         query: () => '',
-        invalidates: () => [{ type: 'User', id: 5 }],
+        invalidatesTags: () => [{ type: 'User', id: 5 }],
       }),
 
       invalidateWrongTypeString: build.mutation<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        invalidates: ['Users'],
+        invalidatesTags: ['Users'],
       }),
       invalidateWrongTypeWithId: build.mutation<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        invalidates: [{ type: 'Users', id: 5 }],
+        invalidatesTags: [{ type: 'Users', id: 5 }],
       }),
       invalidateWrongTypeWithIdAndCallback: build.mutation<unknown, void>({
         query: () => '',
         // @ts-expect-error
-        invalidates: () => [{ type: 'Users', id: 5 }],
+        invalidatesTags: () => [{ type: 'Users', id: 5 }],
       }),
     }),
   });
@@ -163,7 +163,7 @@ describe('endpoint definition typings', () => {
   const api = createApi({
     baseQuery: (from: 'From'): { data: 'To' } | Promise<{ data: 'To' }> => ({ data: 'To' }),
     endpoints: () => ({}),
-    entityTypes: ['typeA', 'typeB'],
+    tagTypes: ['typeA', 'typeB'],
   });
   test('query: query & transformResponse types', () => {
     api.injectEndpoints({
@@ -299,7 +299,7 @@ describe('endpoint definition typings', () => {
     function getNewApi() {
       return createApi({
         baseQuery,
-        entityTypes: ['old'],
+        tagTypes: ['old'],
         endpoints: (build) => ({
           query1: build.query<'out1', 'in1'>({ query: (id) => `${id}` }),
           query2: build.query<'out2', 'in2'>({ query: (id) => `${id}` }),
@@ -328,32 +328,32 @@ describe('endpoint definition typings', () => {
       ]);
     });
 
-    test('warn on wrong entityType', async () => {
+    test('warn on wrong tagType', async () => {
       // only type-test this part
       if (2 > 1) {
         api.enhanceEndpoints({
           endpoints: {
             query1: {
               // @ts-expect-error
-              provides: ['new'],
+              providesTags: ['new'],
             },
             query2: {
               // @ts-expect-error
-              provides: ['missing'],
+              providesTags: ['missing'],
             },
           },
         });
       }
 
       const enhanced = api.enhanceEndpoints({
-        addEntityTypes: ['new'],
+        addTagTypes: ['new'],
         endpoints: {
           query1: {
-            provides: ['new'],
+            providesTags: ['new'],
           },
           query2: {
             // @ts-expect-error
-            provides: ['missing'],
+            providesTags: ['missing'],
           },
         },
       });
@@ -373,11 +373,11 @@ describe('endpoint definition typings', () => {
           endpoints: {
             query1: {
               // returned `enhanced` api contains "new" enitityType
-              provides: ['new'],
+              providesTags: ['new'],
             },
             query2: {
               // @ts-expect-error
-              provides: ['missing'],
+              providesTags: ['missing'],
             },
           },
         });

--- a/test/optimisticUpdates.test.tsx
+++ b/test/optimisticUpdates.test.tsx
@@ -23,9 +23,9 @@ const api = createApi({
     if ('then' in result) return result.then((data: any) => ({ data, meta: 'meta' }));
     return { data: result, meta: 'meta' };
   },
-  entityTypes: ['Post'],
+  tagTypes: ['Post'],
   endpoints: (build) => ({
-    post: build.query<Post, string>({ query: (id) => `post/${id}`, provides: ['Post'] }),
+    post: build.query<Post, string>({ query: (id) => `post/${id}`, providesTags: ['Post'] }),
     updatePost: build.mutation<void, Pick<Post, 'id'> & Partial<Post>, { undoPost: Patch[] }>({
       query: ({ id, ...patch }) => ({ url: `post/${id}`, method: 'PATCH', body: patch }),
       onStart({ id, ...patch }, { dispatch, context }) {
@@ -38,7 +38,7 @@ const api = createApi({
       onError({ id }, { dispatch, context }) {
         dispatch(api.util.patchQueryResult('post', id, context.undoPost));
       },
-      invalidates: ['Post'],
+      invalidatesTags: ['Post'],
     }),
   }),
 });


### PR DESCRIPTION
`entity` -> `tag`
`entityTypes` -> `tagTypes`
`provides` -> `providesTags`
`invalidates` -> `invalidatesTags`
`prefetchThunk` -> `prefetch`