### PR TITLE
Enforce an object return from `selectFromResult`

### DIFF
--- a/docs/api/setupListeners.md
+++ b/docs/api/setupListeners.md
@@ -66,5 +66,5 @@ export function setupListeners(
 If you notice, `onFocus`, `onFocusLost`, `onOffline`, `onOnline` are all actions that are provided to the callback. Additionally, these actions are made available to `api.internalActions` and are able to be used by dispatching them like this:
 
 ```ts title="Manual onFocus event"
-dispatch(api.internalActions.onFocus())
+dispatch(api.internalActions.onFocus());
 ```

--- a/docs/concepts/mutations.md
+++ b/docs/concepts/mutations.md
@@ -208,7 +208,7 @@ export const api = createApi({
           body,
         };
       },
-      invalidates: [{ type: 'Posts', id: 'LIST'} ],
+      invalidates: [{ type: 'Posts', id: 'LIST' }],
     }),
     getPost: build.query<Post, number>({
       query: (id) => `posts/${id}`,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "rm -r dist; rollup -c && node post-build.js",
+    "build": "rimraf dist && rollup -c && node post-build.js",
     "test": "tsdx test",
     "lint": "tsdx lint",
     "prepare": "yarn build",
@@ -147,6 +147,7 @@
     "react-dom": "^16.14.0 || 17.0.0",
     "react-redux": "^7.2.1",
     "react-test-renderer": "^17.0.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.34.2",
     "rollup-plugin-terser": "^7.0.2",
     "shelljs": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "yarn build",
     "prepareExamples": "./prepare-examples.sh",
     "size": "size-limit",
-    "format": "prettier --write \"src/**/*.ts\" \"**/*.md\"",
+    "format": "prettier --write \"src/**/*.ts*\" \"test/**/*.ts*\"  \"**/*.md\"",
     "analyze": "size-limit --why",
     "list-unused-exports": "ts-unused-exports tsconfig.json"
   },

--- a/src/react-hooks/buildHooks.ts
+++ b/src/react-hooks/buildHooks.ts
@@ -33,7 +33,9 @@ export interface MutationHooks<Definition extends MutationDefinition<any, any, a
 /**
  * test description here
  */
-export type UseQuery<D extends QueryDefinition<any, any, any, any>> = <R = UseQueryStateDefaultResult<D>>(
+export type UseQuery<D extends QueryDefinition<any, any, any, any>> = <
+  R extends Record<string, any> = UseQueryStateDefaultResult<D>
+>(
   arg: QueryArgFrom<D>,
   options?: UseQuerySubscriptionOptions & UseQueryStateOptions<D, R>
 ) => UseQueryStateResult<D, R> & ReturnType<UseQuerySubscription<D>>;
@@ -99,7 +101,7 @@ export type UseLazyQuerySubscription<D extends QueryDefinition<any, any, any, an
   options?: SubscriptionOptions
 ) => [(arg: QueryArgFrom<D>) => void, QueryArgFrom<D> | UninitializedValue];
 
-export type QueryStateSelector<R, D extends QueryDefinition<any, any, any, any>> = (
+export type QueryStateSelector<R extends Record<string, any>, D extends QueryDefinition<any, any, any, any>> = (
   state: QueryResultSelectorResult<D>,
   lastResult: R | undefined,
   defaultQueryStateSelector: DefaultQueryStateSelector<D>
@@ -115,7 +117,7 @@ export type UseQueryState<D extends QueryDefinition<any, any, any, any>> = <R = 
   options?: UseQueryStateOptions<D, R>
 ) => UseQueryStateResult<D, R>;
 
-export type UseQueryStateOptions<D extends QueryDefinition<any, any, any, any>, R> = {
+export type UseQueryStateOptions<D extends QueryDefinition<any, any, any, any>, R extends Record<string, any>> = {
   /**
    * Prevents a query from automatically running.
    *
@@ -226,7 +228,7 @@ type UseQueryStateDefaultResult<D extends QueryDefinition<any, any, any, any>> =
   status: QueryStatus;
 };
 
-export type MutationStateSelector<R, D extends MutationDefinition<any, any, any, any>> = (
+export type MutationStateSelector<R extends Record<string, any>, D extends MutationDefinition<any, any, any, any>> = (
   state: MutationResultSelectorResult<D>,
   defaultMutationStateSelector: DefaultMutationStateSelector<D>
 ) => R;
@@ -235,13 +237,15 @@ export type DefaultMutationStateSelector<D extends MutationDefinition<any, any, 
   state: MutationResultSelectorResult<D>
 ) => MutationResultSelectorResult<D>;
 
-export type UseMutationStateOptions<D extends MutationDefinition<any, any, any, any>, R> = {
+export type UseMutationStateOptions<D extends MutationDefinition<any, any, any, any>, R extends Record<string, any>> = {
   selectFromResult?: MutationStateSelector<R, D>;
 };
 
 export type UseMutationStateResult<_ extends MutationDefinition<any, any, any, any>, R> = NoInfer<R>;
 
-export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <R = MutationResultSelectorResult<D>>(
+export type UseMutation<D extends MutationDefinition<any, any, any, any>> = <
+  R extends Record<string, any> = MutationResultSelectorResult<D>
+>(
   options?: UseMutationStateOptions<D, R>
 ) => [
   (

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -1300,6 +1300,36 @@ describe('hooks with createApi defaults set', () => {
       fireEvent.click(addBtn);
       await waitFor(() => expect(screen.getByTestId('renderCount').textContent).toBe('3'));
     });
+
+    test('useQuery with selectFromResult option has a type error if the result is not an object', async () => {
+      function SelectedPost() {
+        const _res1 = api.endpoints.getPosts.useQuery(undefined, {
+          // selectFromResult must always return an object
+          // @ts-expect-error
+          selectFromResult: ({ data }) => data?.length ?? 0,
+        });
+
+        const res2 = api.endpoints.getPosts.useQuery(undefined, {
+          // selectFromResult must always return an object
+          selectFromResult: ({ data }) => ({ size: data?.length ?? 0 }),
+        });
+
+        return (
+          <div>
+            <div data-testid="size2">{res2.size}</div>
+          </div>
+        );
+      }
+
+      render(
+        <div>
+          <SelectedPost />
+        </div>,
+        { wrapper: storeRef.wrapper }
+      );
+
+      expect(screen.getByTestId('length').textContent).toBe('0');
+    });
   });
 
   describe('selectFromResult (mutation) behavior', () => {
@@ -1425,6 +1455,24 @@ describe('hooks with createApi defaults set', () => {
       await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('pending'));
       await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('fulfilled'));
       expect(getRenderCount()).toBe(5);
+    });
+
+    it('useMutation with selectFromResult option has a type error if the result is not an object', async () => {
+      function Counter() {
+        const [increment] = api.endpoints.increment.useMutation({
+          // selectFromResult must always return an object
+          // @ts-expect-error
+          selectFromResult: () => 42,
+        });
+
+        return (
+          <div>
+            <button data-testid="incrementButton" onClick={() => increment(1)}></button>
+          </div>
+        );
+      }
+
+      render(<Counter />, { wrapper: storeRef.wrapper });
     });
   });
 });

--- a/test/buildHooks.test.tsx
+++ b/test/buildHooks.test.tsx
@@ -1328,7 +1328,7 @@ describe('hooks with createApi defaults set', () => {
         { wrapper: storeRef.wrapper }
       );
 
-      expect(screen.getByTestId('length').textContent).toBe('0');
+      expect(screen.getByTestId('size2').textContent).toBe('0');
     });
   });
 


### PR DESCRIPTION
This PR:

- Updates the TS types to ensure that `selectFromResult` always returns an object, not a primitive
- Fixes deletion of the build folder to work cross-platform
- Fixes up formatting

I'd found a lovely edge case in my own app where I had:

```js
selectFromResult: (res => res?.items?.length ?? 0)
```

Unfortunately, due to how the result stuff gets merged together later, I ended up with `number & BunchOfResultData`, which is of course not valid at all.  I had to ensure that I returned the value inside an object.

So, now we enforce that at the type level too.