### PR TITLE
Fix link to hooks in getting started

### DIFF
--- a/docs/api/created-api/overview.md
+++ b/docs/api/created-api/overview.md
@@ -9,7 +9,7 @@ hide_title: true
 
 ## API Slice Overview
 
-When you call [`createApi`](../createApi.md), it automatically generates and returns an API service "slice" object structure containing Redux logic you can use to interact with the endpoints you defined. This slice object includes a reducer to manage cached data, a middleware to manage cache lifetimes and subscriptions, and selectors and thunks for each endpoint. If you imported `createApi` from the React-specific entry point, it also includes auto-generated React hooks for use in your components.
+When you call [`createApi`](../createApi.md#createApi), it automatically generates and returns an API service "slice" object structure containing Redux logic you can use to interact with the endpoints you defined. This slice object includes a reducer to manage cached data, a middleware to manage cache lifetimes and subscriptions, and selectors and thunks for each endpoint. If you imported `createApi` from the React-specific entry point, it also includes auto-generated React hooks for use in your components.
 
 This section documents the contents of that API structure, with the different fields grouped by category. The API types and descriptions are listed on separate pages for each category.
 

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -12,7 +12,7 @@ RTK Query is an advanced data fetching and caching tool, designed to simplify co
 RTK Query is **currently in an alpha state of development**, with the goal of eventually including it directly in the Redux Toolkit library. We encourage you to use it in personal projects, and suggest creating local development branches to try out in actual apps. While we believe the current alpha is stable enough to actually use this library in real code, it's likely that there will be breaking API changes as we iterate on the API design and feature set. We welcome feedback on how it works and ways we can improve the API to help finalize the design!
 
 :::note
-To use the [auto-generated React Hooks](../api/createApi#auto-generated-hooks) as shown below as a TypeScript user, you'll need to use TS4.1+.
+To use the [auto-generated React Hooks](../api/created-api/overview.md#react-hooks) as shown below as a TypeScript user, you'll need to use TS4.1+.
 
 For older versions of TS, you can use `api.endpoints.[endpointName].useQuery/useMutation`
 :::

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -21,7 +21,7 @@ async function defaultBackoff(attempt: number = 0, maxRetries: number = 5) {
   await new Promise((resolve) => setTimeout((res) => resolve(res), timeout));
 }
 
-interface StaggerOptions {
+export interface StaggerOptions {
   /**
    * How many times the query will be retried (default: 5)
    */

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -101,7 +101,7 @@ const featuresToPaths = {
   'Automatic garbage collection': '/api/createApi#keepunuseddatafor',
   Prefetching: '/concepts/prefetching',
   'Optimistic Updates': '/concepts/optimistic-updates',
-  'Auto-generated React Hooks': '/api/createApi#auto-generated-hooks',
+  'Auto-generated React Hooks': '/api/created-api/overview#react-hooks',
   'Runs on every framework': null,
   'Built with TypeScript': null,
 };


### PR DESCRIPTION
Could also link directly to docs/api/created-api/hooks.md instead.